### PR TITLE
Make Kathara able to easier use completely cutstom docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ For `ltest`there are 2 minor adjustments:
 * This will kill and remove any container. 
 
 ## Extend Kathará
-Extending Kathará is actually very simple. Any local or remote Docker image tagged as `kathara/IMAGENAME` can be used with `vstart --image=IMAGENAME --eth=0:A node_name` or with `lstart` having something like that in `lab.conf`: `node_name[image]=IMAGENAME`.
+Extending Kathará is actually very simple. Any local or remote Docker image can be used with `vstart --image=IMAGENAME --eth=0:A node_name` or with `lstart` having something like that in `lab.conf`: `node_name[image]=IMAGENAME`.
 
 To alter (locally) an existing Kathará image refer to the following steps (remember that, by default, Docker needs root or sudo on Linux).
 1. `docker pull kathara/netkit_base` (or `kathara/p4`)
 2. `docker run -tid --name YOUR_NEW_NAME kathara/netkit_base`
 3. `docker exec -ti  YOUR_NEW_NAME bash`
 4. Do your thing, then exit.
-5. `docker commit YOUR_NEW_NAME  kathara/YOUR_NEW_NAME`
+5. `docker commit YOUR_NEW_NAME  YOUR_NEW_NAME`
 6. `docker rm -f YOUR_NEW_NAME`
 
 

--- a/bin/install
+++ b/bin/install
@@ -39,11 +39,11 @@ if [ "$NOT_ADMIN" = "1" ]; then
     sudo chattr -i $NETKIT_HOME/wrapper/bin/netkit_dw
     sudo chmod 000 $NETKIT_HOME/wrapper/netkit_dw.c
     sudo rm $NETKIT_HOME/../config
-    echo "unix_bin=$NETKIT_HOME/wrapper/bin/netkit_dw" > $NETKIT_HOME/../config
+    echo -e "unix_bin=$NETKIT_HOME/wrapper/bin/netkit_dw\nbase_image=kathara/netkit_base" > $NETKIT_HOME/../config
     
 else 
     sudo rm $NETKIT_HOME/../config
-    echo "unix_bin=sudo docker" > $NETKIT_HOME/../config
+    echo -e "unix_bin=sudo docker\nbase_image=kathara/netkit_base" > $NETKIT_HOME/../config
 fi
 
 sudo chown root:root $NETKIT_HOME/*

--- a/bin/python/netkit_commons.py
+++ b/bin/python/netkit_commons.py
@@ -12,8 +12,7 @@ from collections import OrderedDict
 
 DEBUG = True
 PRINT = False
-IMAGE_NAME = 'netkit_base'
-DOCKER_HUB_PREFIX = "kathara/"
+IMAGE_NAME = 'kathara/netkit_base'
 LINUX_TERMINAL_TYPE = 'xterm'
 
 MAC_OS = "darwin"
@@ -50,6 +49,9 @@ if PLATFORM != WINDOWS:
         DOCKER_BIN = kat_config['unix_bin']
     except:
         DOCKER_BIN = os.environ['NETKIT_HOME'] + '/wrapper/bin/netkit_dw'
+
+if 'base_image' in kat_config and not kat_config['base_image'] == '':
+	IMAGE_NAME = kat_config['base_image']
 
 SEPARATOR_WINDOWS = ' & '
 BASH_SEPARATOR = ' ; '
@@ -218,7 +220,7 @@ def create_commands(machines, links, options, metadata, path, execbash=False, no
     count = 0
 
     for machine_name, interfaces in machines.items():
-        this_image = DOCKER_HUB_PREFIX + IMAGE_NAME
+        this_image = IMAGE_NAME
 
         # copying the hostlab directory
         if not execbash:
@@ -241,7 +243,7 @@ def create_commands(machines, links, options, metadata, path, execbash=False, no
                 if opt=='mem' or opt=='M': 
                     machine_option_string+='--memory='+ val.upper() +' '
                 if opt=='image' or opt=='i' or opt=='model-fs' or opt=='m' or opt=='f' or opt=='filesystem': 
-                    this_image = DOCKER_HUB_PREFIX + val
+                    this_image = val
                 if opt=='eth': 
                     app = val.split(":")
                     create_network_commands.append(create_network_template + prefix + app[1])


### PR DESCRIPTION
As already said in the title, this Push request contains changes to let the user more easily use the docker image they wish to use, without the need of re-tagging the image to the format `kathara/IMAGENAME`.

To specify the image used per default for the emulation, the config file also contains now the option `base_image`. By default this setting is set to `kathara/netkit_base`.