### PR TITLE
Removes lab.conf values quotes

### DIFF
--- a/bin/python/netkit_commons.py
+++ b/bin/python/netkit_commons.py
@@ -138,12 +138,12 @@ def lab_parse(path, force=False):
             if not machines.get(name):
                 machines[name] = []
             if len(machines[name]) == 0 or machines[name][len(machines[name])-1][1] == ifnumber - 1:
-                machines[name].append((config.get('dummysection', key), ifnumber))
+                machines[name].append((config.get('dummysection', key).strip().replace('"','').replace("'",''), ifnumber))
         except ValueError:
             option = splitted[0].strip()
             if not options.get(name):
                 options[name] = []
-            options[name].append((option, config.get('dummysection', key)))
+            options[name].append((option, config.get('dummysection', key).strip().replace('"','').replace("'",'')))
     # same with metadata
     metadata = {}
     for m_key in m_keys:


### PR DESCRIPTION
lab.conf values weren't properly cleaned when parsed. 

Interface collision domains had double quotes in the string, so when appended to strings they appeared as `netkit_nt_"C"` instead of `netkit_nt_C`.
Also, other values had the same problem. As an example, if the "image" additional option was used, the resulting string is something like `kathara/"image-name"` instead of `kathara/image-name`.

Of course this happens if you use a lab.conf like this (and I do):
```
pc1[0]="A"
pc1[image]="image_name"

pc2[0]="B"

...
```

I know it is a really stupid parsing problem, but it was causing many troubles in the Kubernetes version of the script! :D