### PR TITLE
Additional options are now applied to all machines

### DIFF
--- a/bin/python/lstart.py
+++ b/bin/python/lstart.py
@@ -136,7 +136,13 @@ if args.options:
 
 # applying parameter options (2/3)
 # adding additional_options to options
-for machine_name, _ in options.items():
+# Loop through the machines
+for machine_name, _ in machines.items():
+    # Check if a machine already has options, if not create a list
+    if machine_name not in options:
+        options[machine_name] = []
+
+    # Append additional_options to options
     options[machine_name] = options[machine_name] + additional_options
 
 filtered_machines = machines


### PR DESCRIPTION
With _lstart_ is possibile to pass additional options to the machines with the _-o_ option. As an example, it is possibile to specify _-o "mem:64m"_ to start all the machines with a memory limit.

However, in the current version, those additional options are not applied to every machine, but only on those who already have at least an option declared in the lab.conf file.

For example, take a look at a lab.conf file like this:
```
pc1[0]="A"
pc1[image]="frr"
pc2[0]="A"
```

As you can see, pc1 has an `image` option which pc2 doesn't have. So pc1 options list will contain a tuple `("image", "frr")`, while pc2 options list will be empty.

Now, if this lab.conf is launched with `lstart -o "mem:64m"`, the expected behavior is that each of the machines will start with the 64MB memory limit. But, as said before, only pc1 starts with this constraint (because its options list is not empty) and pc2 ignores it.

If any of the machines hasn't an additional option, for example:
```
pc1[0]="A"
pc2[0]="A"
```

The `"mem:64m"` is ignored by every machine.

This happens because the `for` that applies command line options ([lstart @ line 137](https://github.com/KatharaFramework/Kathara/blob/master/bin/python/lstart.py#L137)) only loops on machines with options instead of all of them.

The solution is to change the `for` loop, a possible implementation is given in this PR.

Thanks for your attention.