### PR TITLE
max_counter in netkit_commons must be integer

### DIFF
--- a/bin/python/netkit_commons.py
+++ b/bin/python/netkit_commons.py
@@ -227,7 +227,7 @@ def create_commands(machines, links, options, metadata, path, execbash=False, no
         base_ip = u'172.19.0.0'
         max_ip = u'254.255.0.0'
         multiplier = 256 * 256
-        max_counter = ( int(ipaddress.ip_address(max_ip)) - int(ipaddress.ip_address(base_ip)) ) / multiplier
+        max_counter = ( int(ipaddress.ip_address(max_ip)) - int(ipaddress.ip_address(base_ip)) ) // multiplier
         if network_counter == 0: # means it was not set by user
             try:
                 network_counter = int(last_network_counter.readline()) % max_counter


### PR DESCRIPTION
"/" operator in python return a float also if both arguments are integers. But max_counter must be integer because in line 237 you can add at ipaddress.IPv4Address class only an integer and not a float. In fact, this throws an exception:
```
Traceback (most recent call last):
  File "/opt/kathara/bin/python/lstart.py", line 204, in <module>
    (commands, startup_commands, exec_commands) = nc.create_commands(filtered_machines, links, options, metadata, lab_path, args.execbash, no_machines_tmp=(len(machine_name_args) >= 1), network_counter=network_counter)
  File "/opt/kathara/bin/python/netkit_commons.py", line 241, in create_commands
    subnet = ipaddress.ip_address(base_ip) + (network_counter * multiplier)
TypeError: unsupported operand type(s) for +: 'IPv4Address' and 'float' 
```