### PR TITLE
Support for kathara/katharanp Network Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ Dockerfile~
 /.vscode/
 /.vs/
 
-/.idea/
+.idea/
 
 # ISS Compiled file
 /scripts/Windows/Output/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 From the Greek Καθαρά.  
 Implementation of the notorious [Netkit](https://github.com/maxonthegit/netkit-core) using Python. 10 times faster than Netkit and more than 100 times lighter, allows easy configuration and deploy of arbitrary virtual networks with SDN, NFV and traditional routing protocols. The framework has the performances to run in production and our images can emulate most network equipments.
 
-Kathará comes with **P4**, **OpenVSwitch**, **Quagga**, **Bind**, and more, but can also be extended with your own container images. For more information about Kathará images please visit the dedicated [repo](https://github.com/KatharaFramework/Docker-Images).
+Kathará comes with **P4**, **OpenVSwitch**, **Quagga**, **FRRouting**, **Bind**, and more, but can also be extended with your own container images. For more information about Kathará images please visit the dedicated [repo](https://github.com/KatharaFramework/Docker-Images).
 
 ## Installation
 Install Docker and then run the installer. For a step by step guide check the [Wiki](https://github.com/KatharaFramework/Kathara/wiki).

--- a/docs/kathara.conf.5.ronn
+++ b/docs/kathara.conf.5.ronn
@@ -65,6 +65,11 @@ Checks on the correctness of the configuration are performed each time a Kathara
 
 	Default to `true`.
 
+* `enable_ipv6` (boolean):
+	This option enables IPv6 inside the devices.
+
+	Default to `false`.
+
 * `last_checked` (double):
 	Unix time (in milliseconds) of the last online check for Kathara updates. Each week, when the first Kathara command is launched, the system will check if the system and the default image are up-to-date.
 
@@ -84,6 +89,7 @@ Checks on the correctness of the configuration are performed each time a Kathara
 			"device_prefix": "kathara",
 			"debug_level": "INFO",
 			"print_startup_log": true,
+			"enable_ipv6": false,
 			"last_checked": 1570724309.2402148
 		}
   

--- a/src/Resources/api/DockerHubApi.py
+++ b/src/Resources/api/DockerHubApi.py
@@ -7,6 +7,8 @@ from ..exceptions import HTTPConnectionError
 DOCKER_HUB_IMAGE_URL = "https://hub.docker.com/v2/repositories/%s/tags/latest/"
 DOCKER_HUB_KATHARA_URL = "https://hub.docker.com/v2/repositories/kathara/?page_size=-1"
 
+EXCLUDED_IMAGES = ['megalos-bgp-manager', 'katharanp']
+
 
 class DockerHubApi(object):
     @staticmethod
@@ -36,4 +38,4 @@ class DockerHubApi(object):
             logging.debug("DockerHub replied with status code %s.", result.status_code)
             raise HTTPConnectionError("DockerHub replied with status code %s." % result.status_code)
 
-        return filter(lambda x: not x['is_private'], result.json()['results'])
+        return filter(lambda x: not x['is_private'] and x['name'] not in EXCLUDED_IMAGES, result.json()['results'])

--- a/src/Resources/command/LstartCommand.py
+++ b/src/Resources/command/LstartCommand.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 from .. import utils
+from ..exceptions import PrivilegeError
 from ..foundation.command.Command import Command
 from ..manager.ManagerProxy import ManagerProxy
 from ..parser.netkit.DepParser import DepParser
@@ -171,9 +172,9 @@ class LstartCommand(Command):
                         # Since xterm does not work with "sudo", we do not open terminals when lab.ext is present.
                         Setting.get_instance().open_terminals = False
                 else:
-                    raise Exception("You must be root in order to use lab.ext file.")
+                    raise PrivilegeError("You must be root in order to use lab.ext file.")
             else:
-                raise Exception("lab.ext is only available on UNIX systems.")
+                raise OSError("lab.ext is only available on UNIX systems.")
 
         if args.machine_name:
             lab.intersect_machines(args.machine_name)

--- a/src/Resources/command/SettingsCommand.py
+++ b/src/Resources/command/SettingsCommand.py
@@ -338,6 +338,33 @@ class SettingsCommand(Command):
 
         print_startup_log_item = SubmenuItem(print_startup_log_string, print_startup_log_menu, menu)
 
+
+        # Enable ipv6 Option
+        enable_ipv6_string = "Enable IPv6"
+        enable_ipv6_menu = SelectionMenu(strings=[],
+                                         title=enable_ipv6_string,
+                                         subtitle=current_bool("enable_ipv6"),
+                                         formatter=menu_formatter,
+                                         prologue_text="""This option enables IPv6 inside the devices.
+                                                          Default is %s.""" % format_bool(
+                                                          DEFAULTS['enable_ipv6'])
+                                        )
+
+        enable_ipv6_menu.append_item(FunctionItem(text="Yes",
+                                                  function=self.set_setting_value,
+                                                  args=['enable_ipv6', True],
+                                                  should_exit=True
+                                                  )
+                                     )
+        enable_ipv6_menu.append_item(FunctionItem(text="No",
+                                                  function=self.set_setting_value,
+                                                  args=['enable_ipv6', False],
+                                                  should_exit=True
+                                                  )
+                                    )
+
+        enable_ipv6_item = SubmenuItem(enable_ipv6_string, enable_ipv6_menu, menu)
+
         menu.append_item(submenu_item)
         menu.append_item(manager_item)
         menu.append_item(open_terminals_item)
@@ -348,6 +375,7 @@ class SettingsCommand(Command):
         menu.append_item(prefixes_item)
         menu.append_item(debug_level_item)
         menu.append_item(print_startup_log_item)
+        menu.append_item(enable_ipv6_item)
 
         self.menu = menu
 

--- a/src/Resources/command/SettingsCommand.py
+++ b/src/Resources/command/SettingsCommand.py
@@ -3,8 +3,7 @@ from ..exceptions import HTTPConnectionError
 from ..exceptions import SettingsError
 from ..foundation.command.Command import Command
 from ..manager.ManagerProxy import ManagerProxy
-from ..setting.Setting import Setting, DEFAULTS, POSSIBLE_SHELLS, POSSIBLE_TERMINALS, POSSIBLE_DEBUG_LEVELS, \
-    EXCLUDED_IMAGES
+from ..setting.Setting import Setting, DEFAULTS, POSSIBLE_SHELLS, POSSIBLE_TERMINALS, POSSIBLE_DEBUG_LEVELS
 from ..trdparty.consolemenu import *
 from ..trdparty.consolemenu.format import MenuBorderStyleType
 from ..trdparty.consolemenu.items import *
@@ -66,9 +65,6 @@ class SettingsCommand(Command):
 
         try:
             for image in DockerHubApi.get_images():
-                if image['name'] in EXCLUDED_IMAGES:
-                    continue
-
                 image_name = "%s/%s" % (image['namespace'], image['name'])
 
                 select_image_menu.append_item(FunctionItem(text=image_name,

--- a/src/Resources/exceptions.py
+++ b/src/Resources/exceptions.py
@@ -12,6 +12,11 @@ class DockerDaemonConnectionError(Exception):
     pass
 
 
+# OS Exceptions
+class PrivilegeError(Exception):
+    pass
+
+
 # Machine Exceptions
 class MountDeniedError(Exception):
     pass

--- a/src/Resources/manager/docker/DockerImage.py
+++ b/src/Resources/manager/docker/DockerImage.py
@@ -21,7 +21,6 @@ class DockerImage(object):
     def check_update(self, image_name):
         logging.debug("Check update for %s" % image_name)
         local_image_info = self.check_local(image_name)
-        remote_image_info = self.check_remote(image_name)
 
         # Image has been built locally, so there's nothing to compare.
         local_repo_digests = local_image_info.attrs["RepoDigests"]
@@ -29,6 +28,7 @@ class DockerImage(object):
             logging.debug("Image %s is build locally" % image_name)
             return
 
+        remote_image_info = self.check_remote(image_name)
         local_repo_digest = local_repo_digests[0]
         remote_image_digest = remote_image_info["images"][0]["digest"]
 

--- a/src/Resources/manager/docker/DockerImage.py
+++ b/src/Resources/manager/docker/DockerImage.py
@@ -15,6 +15,7 @@ class DockerImage(object):
         return self.client.images.get(image_name)
 
     def pull(self, image_name):
+        print("Pulling image `%s`... This may take a while." % image_name)
         return self.client.images.pull(image_name, tag="latest")
 
     def check_update(self, image_name):
@@ -51,7 +52,6 @@ class DockerImage(object):
             try:
                 # If the image exists on Docker Hub, pulls it.
                 self.check_remote(image_name)
-                print("Pulling image %s... This may take a while." % image_name)
                 self.pull(image_name)
             except ConnectionError:
                 raise ConnectionError("Image `%s` does not exists in local and not Internet connection for Docker Hub."

--- a/src/Resources/manager/docker/DockerImage.py
+++ b/src/Resources/manager/docker/DockerImage.py
@@ -32,6 +32,10 @@ class DockerImage(object):
             except Exception:
                 raise Exception("Image `%s` does not exists neither in local nor on Docker Hub." % image_name)
 
+    def multiple_check_and_pull(self, images):
+        for image in images:
+            self.check_and_pull(image)
+
     @staticmethod
     def check_remote(image_name):
         return DockerHubApi.get_image_information(image_name)

--- a/src/Resources/manager/docker/DockerLink.py
+++ b/src/Resources/manager/docker/DockerLink.py
@@ -14,10 +14,12 @@ from ...setting.Setting import Setting
 
 
 class DockerLink(object):
-    __slots__ = ['client']
+    __slots__ = ['client', 'network_plugin_name']
 
-    def __init__(self, client):
+    def __init__(self, client, network_plugin_name):
         self.client = client
+        self.network_plugin_name = network_plugin_name
+        
 
     def deploy(self, link):
         # Reserved name for bridged connections, ignore.
@@ -34,7 +36,7 @@ class DockerLink(object):
         network_ipam_config = docker.types.IPAMConfig(driver='null')
 
         link.api_object = self.client.networks.create(name=link_name,
-                                                      driver=PLUGIN_NAME,
+                                                      driver=self.network_plugin_name,
                                                       check_duplicate=True,
                                                       ipam=network_ipam_config,
                                                       labels={"lab_hash": link.lab.folder_hash,

--- a/src/Resources/manager/docker/DockerLink.py
+++ b/src/Resources/manager/docker/DockerLink.py
@@ -6,7 +6,6 @@ from multiprocessing.dummy import Pool
 import docker
 from docker import types
 
-from .DockerPlugin import PLUGIN_NAME
 from ... import utils
 from ...model.Link import BRIDGE_LINK_NAME
 from ...os.Networking import Networking
@@ -14,12 +13,12 @@ from ...setting.Setting import Setting
 
 
 class DockerLink(object):
-    __slots__ = ['client', 'network_plugin_name']
+    __slots__ = ['client', 'docker_plugin']
 
-    def __init__(self, client, network_plugin_name):
+    def __init__(self, client, docker_plugin):
         self.client = client
-        self.network_plugin_name = network_plugin_name
-        
+
+        self.docker_plugin = docker_plugin
 
     def deploy(self, link):
         # Reserved name for bridged connections, ignore.
@@ -36,7 +35,7 @@ class DockerLink(object):
         network_ipam_config = docker.types.IPAMConfig(driver='null')
 
         link.api_object = self.client.networks.create(name=link_name,
-                                                      driver=self.network_plugin_name,
+                                                      driver=self.docker_plugin.plugin_name,
                                                       check_duplicate=True,
                                                       ipam=network_ipam_config,
                                                       labels={"lab_hash": link.lab.folder_hash,

--- a/src/Resources/manager/docker/DockerLink.py
+++ b/src/Resources/manager/docker/DockerLink.py
@@ -1,7 +1,6 @@
 import logging
 import re
 from functools import partial
-from multiprocessing import cpu_count
 from multiprocessing.dummy import Pool
 
 import docker
@@ -56,11 +55,10 @@ class DockerLink(object):
     def undeploy(self, lab_hash):
         links = self.get_links_by_filters(lab_hash=lab_hash)
 
-        cpus = cpu_count()
-        links_pool = Pool(cpus)
+        pool_size = utils.get_pool_size()
+        links_pool = Pool(pool_size)
 
-        items = [links] if len(links) < cpus else \
-                        utils.list_chunks(links, cpus)
+        items = [links] if len(links) < pool_size else utils.list_chunks(links, pool_size)
 
         for chunk in items:
             links_pool.map(func=partial(self._undeploy_link, True), iterable=chunk)
@@ -68,11 +66,10 @@ class DockerLink(object):
     def wipe(self, user=None):
         links = self.get_links_by_filters(user=user)
 
-        cpus = cpu_count()
-        links_pool = Pool(cpus)
+        pool_size = utils.get_pool_size()
+        links_pool = Pool(pool_size)
 
-        items = [links] if len(links) < cpus else \
-                        utils.list_chunks(links, cpus)
+        items = [links] if len(links) < pool_size else utils.list_chunks(links, pool_size)
 
         for chunk in items:
             links_pool.map(func=partial(self._undeploy_link, False), iterable=chunk)

--- a/src/Resources/manager/docker/DockerLink.py
+++ b/src/Resources/manager/docker/DockerLink.py
@@ -58,7 +58,7 @@ class DockerLink(object):
         pool_size = utils.get_pool_size()
         links_pool = Pool(pool_size)
 
-        items = [links] if len(links) < pool_size else utils.list_chunks(links, pool_size)
+        items = utils.chunk_list(links, pool_size)
 
         for chunk in items:
             links_pool.map(func=partial(self._undeploy_link, True), iterable=chunk)
@@ -69,7 +69,7 @@ class DockerLink(object):
         pool_size = utils.get_pool_size()
         links_pool = Pool(pool_size)
 
-        items = [links] if len(links) < pool_size else utils.list_chunks(links, pool_size)
+        items = utils.chunk_list(links, pool_size)
 
         for chunk in items:
             links_pool.map(func=partial(self._undeploy_link, False), iterable=chunk)

--- a/src/Resources/manager/docker/DockerMachine.py
+++ b/src/Resources/manager/docker/DockerMachine.py
@@ -132,8 +132,6 @@ class DockerMachine(object):
         if Setting.get_instance().hosthome_mount:
             volumes[utils.get_current_user_home()] = {'bind': '/hosthome', 'mode': 'rw'}
 
-        # self.docker_image.check_and_pull(image)
-
         container_name = self.get_container_name(machine.name, machine.lab.folder_hash)
         try:
             machine_container = self.client.containers.create(image=image,

--- a/src/Resources/manager/docker/DockerMachine.py
+++ b/src/Resources/manager/docker/DockerMachine.py
@@ -1,7 +1,6 @@
 import logging
 from functools import partial
 from itertools import islice
-from multiprocessing import cpu_count
 from multiprocessing.dummy import Pool
 from subprocess import Popen
 
@@ -236,11 +235,10 @@ class DockerMachine(object):
     def undeploy(self, lab_hash, selected_machines=None):
         machines = self.get_machines_by_filters(lab_hash=lab_hash)
 
-        cpus = cpu_count()
-        machines_pool = Pool(cpus)
+        pool_size = utils.get_pool_size()
+        machines_pool = Pool(pool_size)
 
-        items = [machines] if len(machines) < cpus else \
-                              utils.list_chunks(machines, cpus)
+        items = [machines] if len(machines) < pool_size else utils.list_chunks(machines, pool_size)
 
         for chunk in items:
             machines_pool.map(func=partial(self._undeploy_machine, selected_machines, True), iterable=chunk)
@@ -248,11 +246,10 @@ class DockerMachine(object):
     def wipe(self, user=None):
         machines = self.get_machines_by_filters(user=user)
 
-        cpus = cpu_count()
-        machines_pool = Pool(cpus)
+        pool_size = utils.get_pool_size()
+        machines_pool = Pool(pool_size)
 
-        items = [machines] if len(machines) < cpus else \
-            utils.list_chunks(machines, cpus)
+        items = [machines] if len(machines) < pool_size else utils.list_chunks(machines, pool_size)
 
         for chunk in items:
             machines_pool.map(func=partial(self._undeploy_machine, [], False), iterable=chunk)

--- a/src/Resources/manager/docker/DockerMachine.py
+++ b/src/Resources/manager/docker/DockerMachine.py
@@ -154,10 +154,12 @@ class DockerMachine(object):
 
         sysctl_parameters["net.ipv4.ip_forward"] = 1
         sysctl_parameters["net.ipv4.icmp_ratelimit"] = 0
-        sysctl_parameters["net.ipv6.conf.all.forwarding"] = 1
-        sysctl_parameters["net.ipv6.icmp.ratelimit"] = 0
-        sysctl_parameters["net.ipv6.conf.default.disable_ipv6"] = 0
-        sysctl_parameters["net.ipv6.conf.all.disable_ipv6"] = 0
+
+        if Setting.get_instance().enable_ipv6:
+            sysctl_parameters["net.ipv6.conf.all.forwarding"] = 1
+            sysctl_parameters["net.ipv6.icmp.ratelimit"] = 0
+            sysctl_parameters["net.ipv6.conf.default.disable_ipv6"] = 0
+            sysctl_parameters["net.ipv6.conf.all.disable_ipv6"] = 0
 
         volumes = {}
 

--- a/src/Resources/manager/docker/DockerMachine.py
+++ b/src/Resources/manager/docker/DockerMachine.py
@@ -119,6 +119,10 @@ class DockerMachine(object):
 
         sysctl_parameters["net.ipv4.ip_forward"] = 1
         sysctl_parameters["net.ipv4.icmp_ratelimit"] = 0
+        sysctl_parameters["net.ipv6.conf.all.forwarding"] = 1
+        sysctl_parameters["net.ipv6.icmp.ratelimit"] = 0
+        sysctl_parameters["net.ipv6.conf.default.disable_ipv6"] = 0
+        sysctl_parameters["net.ipv6.conf.all.disable_ipv6"] = 0
 
         volumes = {}
 

--- a/src/Resources/manager/docker/DockerMachine.py
+++ b/src/Resources/manager/docker/DockerMachine.py
@@ -236,7 +236,7 @@ class DockerMachine(object):
         pool_size = utils.get_pool_size()
         machines_pool = Pool(pool_size)
 
-        items = [machines] if len(machines) < pool_size else utils.list_chunks(machines, pool_size)
+        items = utils.chunk_list(machines, pool_size)
 
         for chunk in items:
             machines_pool.map(func=partial(self._undeploy_machine, selected_machines, True), iterable=chunk)
@@ -247,7 +247,7 @@ class DockerMachine(object):
         pool_size = utils.get_pool_size()
         machines_pool = Pool(pool_size)
 
-        items = [machines] if len(machines) < pool_size else utils.list_chunks(machines, pool_size)
+        items = utils.chunk_list(machines, pool_size)
 
         for chunk in items:
             machines_pool.map(func=partial(self._undeploy_machine, [], False), iterable=chunk)

--- a/src/Resources/manager/docker/DockerMachine.py
+++ b/src/Resources/manager/docker/DockerMachine.py
@@ -132,7 +132,7 @@ class DockerMachine(object):
         if Setting.get_instance().hosthome_mount:
             volumes[utils.get_current_user_home()] = {'bind': '/hosthome', 'mode': 'rw'}
 
-        self.docker_image.check_and_pull(image)
+        # self.docker_image.check_and_pull(image)
 
         container_name = self.get_container_name(machine.name, machine.lab.folder_hash)
         try:

--- a/src/Resources/manager/docker/DockerManager.py
+++ b/src/Resources/manager/docker/DockerManager.py
@@ -90,7 +90,7 @@ class DockerManager(IManager):
         self.docker_image = DockerImage(self.client)
 
         self.docker_machine = DockerMachine(self.client, self.docker_image)
-        self.docker_link = DockerLink(self.client)
+        self.docker_link = DockerLink(self.client, docker_plugin.plugin_name)
 
     @privileged
     def deploy_lab(self, lab, privileged_mode=False):

--- a/src/Resources/manager/docker/DockerManager.py
+++ b/src/Resources/manager/docker/DockerManager.py
@@ -90,7 +90,7 @@ class DockerManager(IManager):
         self.docker_image = DockerImage(self.client)
 
         self.docker_machine = DockerMachine(self.client, self.docker_image)
-        self.docker_link = DockerLink(self.client, docker_plugin.plugin_name)
+        self.docker_link = DockerLink(self.client, docker_plugin)
 
     @privileged
     def deploy_lab(self, lab, privileged_mode=False):

--- a/src/Resources/manager/docker/DockerManager.py
+++ b/src/Resources/manager/docker/DockerManager.py
@@ -17,6 +17,8 @@ from ...exceptions import DockerDaemonConnectionError
 from ...foundation.manager.IManager import IManager
 from ...model.Link import BRIDGE_LINK_NAME
 
+MAX_CONNECTION_TIMEOUT = 180
+
 
 def pywin_import_stub():
     """
@@ -78,7 +80,9 @@ class DockerManager(IManager):
 
     @check_docker_status
     def __init__(self):
-        self.client = docker.from_env()
+        self.client = docker.from_env(timeout=MAX_CONNECTION_TIMEOUT, 
+                                      max_pool_size=utils.get_pool_size()
+                                      )
 
         docker_plugin = DockerPlugin(self.client)
         docker_plugin.check_and_download_plugin()

--- a/src/Resources/manager/docker/DockerManager.py
+++ b/src/Resources/manager/docker/DockerManager.py
@@ -106,12 +106,8 @@ class DockerManager(IManager):
         link.api_object = docker_bridge
 
         # Check and pulling machine images
-        pulled_images = []
-        for machine in set(lab.machines.values()):
-            image_name = machine.get_image()
-            if image_name not in pulled_images:
-                self.check_image(image_name)
-                pulled_images.append(image_name)
+        lab_images = set(map(lambda x: x.get_image(), lab.machines.values()))
+        self.docker_image.multiple_check_and_pull(lab_images)
                 
         # Deploy all lab machines.
         # If there is no lab.dep file, machines can be deployed using multithreading.

--- a/src/Resources/manager/docker/DockerManager.py
+++ b/src/Resources/manager/docker/DockerManager.py
@@ -95,7 +95,7 @@ class DockerManager(IManager):
         link_pool = Pool(pool_size)
 
         links = lab.links.items()
-        items = [links] if len(links) < pool_size else utils.list_chunks(links, pool_size)
+        items = utils.chunk_list(links, pool_size)
 
         for chunk in items:
             link_pool.map(func=self._deploy_link, iterable=chunk)
@@ -116,7 +116,7 @@ class DockerManager(IManager):
             machines_pool = Pool(pool_size)
 
             machines = lab.machines.items()
-            items = [machines] if len(machines) < pool_size else utils.list_chunks(machines, pool_size)
+            items = utils.chunk_list(machines, pool_size)
 
             for chunk in items:
                 machines_pool.map(func=partial(self._deploy_and_start_machine, privileged_mode), iterable=chunk)

--- a/src/Resources/manager/docker/DockerManager.py
+++ b/src/Resources/manager/docker/DockerManager.py
@@ -105,6 +105,14 @@ class DockerManager(IManager):
         link = lab.get_or_new_link(BRIDGE_LINK_NAME)
         link.api_object = docker_bridge
 
+        # Check and pulling machine images
+        pulled_images = []
+        for machine in set(lab.machines.values()):
+            image_name = machine.get_image()
+            if image_name not in pulled_images:
+                self.check_image(image_name)
+                pulled_images.append(image_name)
+                
         # Deploy all lab machines.
         # If there is no lab.dep file, machines can be deployed using multithreading.
         # If not, they're started sequentially

--- a/src/Resources/manager/docker/DockerPlugin.py
+++ b/src/Resources/manager/docker/DockerPlugin.py
@@ -1,0 +1,25 @@
+from docker.errors import NotFound
+import logging
+
+PLUGIN_NAME = "kathara/katharanp:latest"
+
+
+class DockerPlugin(object):
+    __slots__ = ['client']
+
+    def __init__(self, client):
+        self.client = client
+
+    def check_and_download_plugin(self):
+        try:
+            logging.debug("Checking plugin `%s`..." % PLUGIN_NAME)
+
+            plugin = self.client.plugins.get(PLUGIN_NAME)
+        except NotFound:
+            logging.info("Installing Kathara Network Plugin...")
+            plugin = self.client.plugins.install(PLUGIN_NAME)
+            logging.info("Kathara Network Plugin installed successfully!")
+
+        if not plugin.enabled:
+            logging.debug("Enabling plugin `%s`..." % PLUGIN_NAME)
+            plugin.enable()

--- a/src/Resources/manager/docker/DockerPlugin.py
+++ b/src/Resources/manager/docker/DockerPlugin.py
@@ -1,9 +1,9 @@
 import logging
-import os
 
 from docker.errors import NotFound
 
 from ... import utils
+from ...os.Networking import Networking
 
 PLUGIN_NAME = "kathara/katharanp"
 BUSTER_TAG = "buster"
@@ -17,7 +17,7 @@ class DockerPlugin(object):
         self.client = client
 
         def _select_plugin_name_linux():
-            iptables_version = os.popen("/sbin/iptables --version").read().strip()
+            iptables_version = Networking.get_iptables_version()
 
             return "%s:%s" % (PLUGIN_NAME, BUSTER_TAG) if 'nf_tables' in iptables_version else \
                    "%s:%s" % (PLUGIN_NAME, STRETCH_TAG)

--- a/src/Resources/manager/docker/DockerPlugin.py
+++ b/src/Resources/manager/docker/DockerPlugin.py
@@ -1,27 +1,43 @@
 from docker.errors import NotFound
 import logging
+import os
+from ... import utils
 
-PLUGIN_NAME = "kathara/katharanp:latest"
-
+PLUGIN_NAME = "kathara/katharanp"
+PLUGIN_NAME_BUSTER = "kathara/katharanp:buster"
+PLUGIN_NAME_STRETCH = "kathara/katharanp:stretch"
 
 class DockerPlugin(object):
-    __slots__ = ['client']
+    __slots__ = ['client', 'plugin_name']
 
     def __init__(self, client):
         self.client = client
+        self.plugin_name = ""
+        utils.exec_by_platform(self._select_plugin_name_linux, self._select_plugin_name, self._select_plugin_name)
+
+    def _select_plugin_name_linux(self):
+        iptables_version = os.popen("iptables --version").read().strip()
+        
+        if 'nf_tables' in iptables_version:
+            self.plugin_name = PLUGIN_NAME_BUSTER
+        else: 
+            self.plugin_name = PLUGIN_NAME_STRETCH
+
+    def _select_plugin_name(self): 
+        self.plugin_name = PLUGIN_NAME_BUSTER
 
     def check_and_download_plugin(self):
         try:
-            logging.debug("Checking plugin `%s`..." % PLUGIN_NAME)
+            logging.debug("Checking plugin `%s`..." % self.plugin_name)
 
-            plugin = self.client.plugins.get(PLUGIN_NAME)
+            plugin = self.client.plugins.get(self.plugin_name)
             # Check for plugin updates.
             plugin.upgrade()
         except NotFound:
             logging.info("Installing Kathara Network Plugin...")
-            plugin = self.client.plugins.install(PLUGIN_NAME)
+            plugin = self.client.plugins.install(self.plugin_name)
             logging.info("Kathara Network Plugin installed successfully!")
 
         if not plugin.enabled:
-            logging.debug("Enabling plugin `%s`..." % PLUGIN_NAME)
+            logging.debug("Enabling plugin `%s`..." % self.plugin_name)
             plugin.enable()

--- a/src/Resources/manager/docker/DockerPlugin.py
+++ b/src/Resources/manager/docker/DockerPlugin.py
@@ -1,30 +1,31 @@
-from docker.errors import NotFound
 import logging
 import os
+
+from docker.errors import NotFound
+
 from ... import utils
 
 PLUGIN_NAME = "kathara/katharanp"
-PLUGIN_NAME_BUSTER = "kathara/katharanp:buster"
-PLUGIN_NAME_STRETCH = "kathara/katharanp:stretch"
+BUSTER_TAG = "buster"
+STRETCH_TAG = "stretch"
+
 
 class DockerPlugin(object):
     __slots__ = ['client', 'plugin_name']
 
     def __init__(self, client):
         self.client = client
-        self.plugin_name = ""
-        utils.exec_by_platform(self._select_plugin_name_linux, self._select_plugin_name, self._select_plugin_name)
 
-    def _select_plugin_name_linux(self):
-        iptables_version = os.popen("iptables --version").read().strip()
-        
-        if 'nf_tables' in iptables_version:
-            self.plugin_name = PLUGIN_NAME_BUSTER
-        else: 
-            self.plugin_name = PLUGIN_NAME_STRETCH
+        def _select_plugin_name_linux():
+            iptables_version = os.popen("/sbin/iptables --version").read().strip()
 
-    def _select_plugin_name(self): 
-        self.plugin_name = PLUGIN_NAME_BUSTER
+            return "%s:%s" % (PLUGIN_NAME, BUSTER_TAG) if 'nf_tables' in iptables_version else \
+                   "%s:%s" % (PLUGIN_NAME, STRETCH_TAG)
+
+        self.plugin_name = utils.exec_by_platform(_select_plugin_name_linux,
+                                                  lambda: "%s:%s" % (PLUGIN_NAME, BUSTER_TAG),
+                                                  lambda: "%s:%s" % (PLUGIN_NAME, BUSTER_TAG)
+                                                  )
 
     def check_and_download_plugin(self):
         try:

--- a/src/Resources/manager/docker/DockerPlugin.py
+++ b/src/Resources/manager/docker/DockerPlugin.py
@@ -15,6 +15,7 @@ class DockerPlugin(object):
             logging.debug("Checking plugin `%s`..." % PLUGIN_NAME)
 
             plugin = self.client.plugins.get(PLUGIN_NAME)
+
         except NotFound:
             logging.info("Installing Kathara Network Plugin...")
             plugin = self.client.plugins.install(PLUGIN_NAME)

--- a/src/Resources/manager/docker/DockerPlugin.py
+++ b/src/Resources/manager/docker/DockerPlugin.py
@@ -15,7 +15,8 @@ class DockerPlugin(object):
             logging.debug("Checking plugin `%s`..." % PLUGIN_NAME)
 
             plugin = self.client.plugins.get(PLUGIN_NAME)
-
+            # Check for plugin updates.
+            plugin.upgrade()
         except NotFound:
             logging.info("Installing Kathara Network Plugin...")
             plugin = self.client.plugins.install(PLUGIN_NAME)

--- a/src/Resources/model/ExternalLink.py
+++ b/src/Resources/model/ExternalLink.py
@@ -1,3 +1,6 @@
+MAX_INTERFACE_NAME_LENGTH = 15
+
+
 class ExternalLink(object):
     __slots__ = ['interface', 'vlan']
 
@@ -5,8 +8,21 @@ class ExternalLink(object):
         self.interface = interface
         self.vlan = vlan
 
-    def get_name(self):
-        return "%s.%s" % (self.interface, self.vlan) if self.vlan else self.interface
+    def get_name_and_vlan(self):
+        # VLAN is defined
+        if self.vlan:
+            vlan_name_length = len(".%s" % self.vlan)
+
+            # If the length of interface name + vlan tag is more than 15 chars, we truncate the interface name to
+            # 15 - VLAN_NAME_LENGTH in order to fit the whole string in 15 chars
+            return self.interface, self.vlan if len(self.interface) + vlan_name_length <= MAX_INTERFACE_NAME_LENGTH \
+                   else self.interface[0:(MAX_INTERFACE_NAME_LENGTH - vlan_name_length)], self.vlan
+
+        return self.interface, None
+
+    def get_full_name(self):
+        (name, vlan) = self.get_name_and_vlan()
+        return name if not vlan else "%s.%s" % (name, vlan)
 
     def __repr__(self):
         return "ExternalLink(%s, %s)" % (self.interface, self.vlan)

--- a/src/Resources/model/Machine.py
+++ b/src/Resources/model/Machine.py
@@ -179,7 +179,7 @@ class Machine(object):
 
         def osx_connect():
             import appscript
-            complete_osx_command = "cd %s && clear && %s && exit" % (self.lab.path, connect_command)
+            complete_osx_command = "cd \"%s\" && clear && %s && exit" % (self.lab.path, connect_command)
             logging.debug("Opening OSX terminal with command: %s." % complete_osx_command)
             appscript.app('Terminal').do_script(complete_osx_command)
 

--- a/src/Resources/os/Networking.py
+++ b/src/Resources/os/Networking.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 
 class Networking(object):
@@ -63,7 +64,8 @@ class Networking(object):
         ip.link(
             "set",
             index=interface_index,
-            master=bridge_index
+            master=bridge_index,
+            state="up"
         )
 
         logging.debug("Interface ID = %d attached to bridge %s." % (interface_index, bridge_name))
@@ -94,3 +96,7 @@ class Networking(object):
         )
 
         ip.close()
+
+    @staticmethod
+    def get_iptables_version():
+        return os.popen("/sbin/iptables --version").read().strip()

--- a/src/Resources/setting/Setting.py
+++ b/src/Resources/setting/Setting.py
@@ -28,14 +28,15 @@ DEFAULTS = {
     "net_prefix": 'kathara',
     "device_prefix": 'kathara',
     "debug_level": 'INFO',
-    "print_startup_log": True
+    "print_startup_log": True,
+    "enable_ipv6": False
 }
 
 
 class Setting(object):
     __slots__ = ['image', 'manager_type', 'terminal', 'open_terminals',
                  'hosthome_mount', 'shared_mount', 'device_shell', 'net_prefix', 'device_prefix', 'debug_level',
-                 'print_startup_log', 'last_checked']
+                 'print_startup_log', 'enable_ipv6', 'last_checked']
 
     __instance = None
 
@@ -207,5 +208,6 @@ class Setting(object):
                 "device_prefix": self.device_prefix,
                 "debug_level": self.debug_level,
                 "print_startup_log": self.print_startup_log,
-                "last_checked": self.last_checked
+                "last_checked": self.last_checked,
+                "enable_ipv6": self.enable_ipv6
                 }

--- a/src/Resources/setting/Setting.py
+++ b/src/Resources/setting/Setting.py
@@ -8,11 +8,6 @@ from .. import version
 from ..api.GitHubApi import GitHubApi
 from ..exceptions import HTTPConnectionError, SettingsError
 
-MAX_K8S_NUMBER = (1 << 24) - 20
-
-DOCKER = "docker"
-K8S = "k8s"
-
 POSSIBLE_SHELLS = ["/bin/bash", "/bin/sh", "/bin/ash", "/bin/ksh", "/bin/zsh", "/bin/fish", "/bin/csh", "/bin/tcsh"]
 POSSIBLE_TERMINALS = ["/usr/bin/xterm", "/usr/bin/konsole"]
 POSSIBLE_DEBUG_LEVELS = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]
@@ -35,8 +30,6 @@ DEFAULTS = {
     "debug_level": 'INFO',
     "print_startup_log": True
 }
-EXCLUDED_FILES = ['.DS_Store']
-EXCLUDED_IMAGES = ['megalos-bgp-manager']
 
 
 class Setting(object):
@@ -139,7 +132,7 @@ class Setting(object):
         self.check_terminal()
 
         current_time = time.time()
-        # After 1 week, check if a new image and Kathara version has been released.
+        # After 1 week, check if a new Kathara version has been released.
         if current_time - self.last_checked > ONE_WEEK:
             logging.debug(utils.format_headers("Checking Updates"))
             checked = True

--- a/src/Resources/setting/Setting.py
+++ b/src/Resources/setting/Setting.py
@@ -136,8 +136,6 @@ class Setting(object):
     def check(self):
         self.check_manager()
 
-        self.check_image()
-
         self.check_terminal()
 
         current_time = time.time()
@@ -159,16 +157,6 @@ class Setting(object):
             except HTTPConnectionError:
                 logging.debug("Connection to GitHub failed, passing...")
                 checked = False
-
-            if self.manager_type == DOCKER:
-                logging.debug("Checking Docker Image version...")
-
-                try:
-                    from ..manager.ManagerProxy import ManagerProxy
-                    ManagerProxy.get_instance().check_updates(self)
-                except HTTPConnectionError:
-                    logging.debug("Connection to DockerHub failed, passing...")
-                    checked = False
 
             if checked:
                 self.last_checked = current_time

--- a/src/Resources/utils.py
+++ b/src/Resources/utils.py
@@ -105,8 +105,7 @@ def confirmation_prompt(prompt_string, callback_yes, callback_no):
 
 def get_pool_size():
     # Pool Size is limited to 10 due to urllib3 (used by DockerPy)
-    cpus = cpu_count()
-    return min(10, cpus)
+    return cpu_count()
 
 
 # Platform Specific Functions

--- a/src/Resources/utils.py
+++ b/src/Resources/utils.py
@@ -5,15 +5,16 @@ import math
 import os
 import re
 import shutil
-import sys
 import tarfile
 import tempfile
 from io import BytesIO
 from itertools import islice
-from sys import platform as _platform
+from multiprocessing import cpu_count
 
+import sys
 from binaryornot.check import is_binary
 from slug import slug
+from sys import platform as _platform
 
 from .setting.Setting import EXCLUDED_FILES
 from .trdparty.consolemenu import PromptUtils, Screen
@@ -96,6 +97,12 @@ def confirmation_prompt(prompt_string, callback_yes, callback_no):
         return callback_no()
 
     return callback_yes()
+
+
+def get_pool_size():
+    # Pool Size is limited to 10 due to urllib3 (used by DockerPy)
+    cpus = cpu_count()
+    return min(10, cpus)
 
 
 # Platform Specific Functions

--- a/src/Resources/utils.py
+++ b/src/Resources/utils.py
@@ -106,7 +106,7 @@ def confirmation_prompt(prompt_string, callback_yes, callback_no):
 
 
 def get_pool_size():
-    return cpu_count()
+    return min(10, cpu_count())
 
 
 # Platform Specific Functions

--- a/src/Resources/utils.py
+++ b/src/Resources/utils.py
@@ -89,6 +89,10 @@ def list_chunks(iterable, size):
         item = list(islice(it, size))
 
 
+def chunk_list(iterable, size):
+    return [iterable] if len(iterable) < size else list_chunks(iterable, size)
+
+
 def confirmation_prompt(prompt_string, callback_yes, callback_no):
     prompt_utils = PromptUtils(Screen())
     answer = prompt_utils.prompt_for_bilateral_choice(prompt_string, 'y', 'n')

--- a/src/Resources/utils.py
+++ b/src/Resources/utils.py
@@ -16,7 +16,6 @@ from binaryornot.check import is_binary
 from slug import slug
 from sys import platform as _platform
 
-from .setting.Setting import EXCLUDED_FILES
 from .trdparty.consolemenu import PromptUtils, Screen
 
 # Platforms constants definition.
@@ -24,6 +23,9 @@ MAC_OS = "darwin"
 WINDOWS = "win32"
 LINUX = "linux"
 LINUX2 = "linux2"
+
+# List of ignored files
+EXCLUDED_FILES = ['.DS_Store']
 
 
 # Generic Functions
@@ -104,7 +106,6 @@ def confirmation_prompt(prompt_string, callback_yes, callback_no):
 
 
 def get_pool_size():
-    # Pool Size is limited to 10 due to urllib3 (used by DockerPy)
     return cpu_count()
 
 

--- a/src/kathara.py
+++ b/src/kathara.py
@@ -66,8 +66,7 @@ class KatharaEntryPoint(object):
         }
 
         try:
-            # Load config file
-            Setting.get_instance()
+            # Check settings
             Setting.get_instance().check()
         except (SettingsError, DockerDaemonConnectionError) as e:
             logging.critical(str(e))

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,5 +6,6 @@ requests>=2.22.0;
 slug>=2.0;
 deepdiff>=4.0.9;
 pyroute2>=0.5.7;
+progress>=1.5;
 appscript>=1.1.0; sys_platform == 'darwin'
 pypiwin32>=223; sys_platform == 'win32'


### PR DESCRIPTION
This pull request adds the support for the `kathara/katharanp` Network Plugin. 

Networks are now created using our custom Docker Plugin instead of `bridge`. This avoids `brctl` patch and IPv4 Pools assignments.

Other minor fixes are included (such as Manager polishing, a progress bar when deploying/deleting links and machines, fixes for `lab.ext` support, image update process improvements, etc.)

IPv6 support can now be enabled from `kathara settings`, by default is disabled.