### PR TITLE
Added device's shell as a label to the corresponding Docker container

### DIFF
--- a/docs/kathara-lab.conf.5.ronn
+++ b/docs/kathara-lab.conf.5.ronn
@@ -42,7 +42,7 @@ In order to establish a uniform convention, comment lines should always start wi
 	Sets a sysctl option for this device. Only the `net.` namespace is allowed to be set. Can be set multiple times per machine, each will add a new entry (unless the same config item is used again).
 
 * `shell` (string):
-  Use the specified shell to connect to the device, e.g., when `kathara connect` is called.
+    Use the specified shell to connect to the device, e.g., when `kathara connect` is called.
 
 ## LAB META INFORMATION
 
@@ -77,7 +77,7 @@ It is also possible to provide descriptive information about a lab by using one 
 
 		pc2[0]="C"
 		pc2[mem]=128m
-    pc2[shell]="/bin/sh"
+        pc2[shell]="/bin/sh"
 
 Example of a `lab.conf`(5) file.
 

--- a/docs/kathara-lab.conf.5.ronn
+++ b/docs/kathara-lab.conf.5.ronn
@@ -41,6 +41,9 @@ In order to establish a uniform convention, comment lines should always start wi
 * `sysctl` (string):
 	Sets a sysctl option for this device. Only the `net.` namespace is allowed to be set. Can be set multiple times per machine, each will add a new entry (unless the same config item is used again).
 
+* `shell` (string):
+  Use the specified shell to connect to the device, e.g., when `kathara connect` is called.
+
 ## LAB META INFORMATION
 
 It is also possible to provide descriptive information about a lab by using one of the following special assignments:
@@ -74,7 +77,8 @@ It is also possible to provide descriptive information about a lab by using one 
 
 		pc2[0]="C"
 		pc2[mem]=128m
-  
+    pc2[shell]="/bin/sh"
+
 Example of a `lab.conf`(5) file.
 
 m4_include(footer.txt)

--- a/src/Resources/foundation/manager/IManager.py
+++ b/src/Resources/foundation/manager/IManager.py
@@ -19,7 +19,7 @@ class IManager(ABC):
         raise NotImplementedError("You must implement `wipe` method.")
 
     @abstractmethod
-    def connect_tty(self, lab_hash, machine_name, shell, logs=False):
+    def connect_tty(self, lab_hash, machine_name, shell=None, logs=False):
         raise NotImplementedError("You must implement `connect_tty` method.")
 
     @abstractmethod

--- a/src/Resources/manager/ManagerProxy.py
+++ b/src/Resources/manager/ManagerProxy.py
@@ -39,7 +39,7 @@ class ManagerProxy(IManager):
     def wipe(self, all_users=False):
         self.manager.wipe(all_users)
 
-    def connect_tty(self, lab_hash, machine_name, shell, logs=False):
+    def connect_tty(self, lab_hash, machine_name, shell=None, logs=False):
         self.manager.connect_tty(lab_hash, machine_name, shell, logs)
 
     def exec(self, machine, command):

--- a/src/Resources/manager/docker/DockerMachine.py
+++ b/src/Resources/manager/docker/DockerMachine.py
@@ -194,7 +194,9 @@ class DockerMachine(object):
                                                                       "lab_hash": machine.lab.folder_hash,
                                                                       "user": utils.get_current_user_name(),
                                                                       "app": "kathara",
-                                                                      "shell": machine.meta["shell"] if "shell" in machine.meta else Setting.get_instance().device_shell
+                                                                      "shell": machine.meta["shell"]
+                                                                               if "shell" in machine.meta
+                                                                               else Setting.get_instance().device_shell
                                                                       }
                                                               )
         except APIError as e:
@@ -312,15 +314,15 @@ class DockerMachine(object):
             if log:
                 progress_bar.next()
 
-    def connect(self, lab_hash, machine_name, shell, logs=False):
+    def connect(self, lab_hash, machine_name, shell=None, logs=False):
         container = self.get_machine(lab_hash=lab_hash, machine_name=machine_name)
 
         if not shell:
-            shell = container.labels['shell']
+            shell = shlex.split(container.labels['shell'])
         else:
             shell = shlex.split(shell) if type(shell) == str else shell
 
-        logging.debug("Connect to machine `%s` with shell: %s" % (machine_name,shell))
+        logging.debug("Connect to machine `%s` with shell: %s" % (machine_name, shell))
 
         if logs and Setting.get_instance().print_startup_log:
             result_string = self.exec(container,

--- a/src/Resources/manager/docker/DockerManager.py
+++ b/src/Resources/manager/docker/DockerManager.py
@@ -120,7 +120,7 @@ class DockerManager(IManager):
         self.docker_link.wipe(user=user_name)
 
     @privileged
-    def connect_tty(self, lab_hash, machine_name, shell, logs=False):
+    def connect_tty(self, lab_hash, machine_name, shell=None, logs=False):
         self.docker_machine.connect(lab_hash=lab_hash,
                                     machine_name=machine_name,
                                     shell=shell,


### PR DESCRIPTION
---
name: Feature implementation for device shells
about: Each node can have it's own shell

---

**Is your merge request related to a problem? Please describe.**
Until this request, shells needed to be globally defined or given as a parameter to `kathara connect --shell`. 

**Describe the solution you propose**
I added a label to the corresponding docker container, such that the shell can be specified in `lab.conf` with `pc1[shell]=/bin/bash` and is evaluated when "kathara connect" is called.

**Describe alternatives you've considered**
None.