### PR TITLE
Add iTerm as terminal option for macOS

### DIFF
--- a/docs/kathara.conf.5.ronn
+++ b/docs/kathara.conf.5.ronn
@@ -19,14 +19,14 @@ Checks on the correctness of the configuration are performed each time a Kathara
     Manager used to launch the lab.
 
     Default to `docker`.
-	
+
 * `terminal` (string):
-	This parameter determines the terminal emulator application to be used for device terminals. The application must be correctly installed in the host system. This option is only visible on Linux and macOS.
+	This parameter determines the terminal emulator application to be used for device terminals. The application must be correctly installed in the host system. This option is only visible on Linux and macOS. On macOS options other than "iTerm" or "TMUX" default to the system terminal.
 
 	Default to `/usr/bin/xterm`.
 
 * `open_terminals` (boolean):
-	This parameter determines if device terminal should be opened when starting it. 
+	This parameter determines if device terminal should be opened when starting it.
 
 	Default to `true`.
 
@@ -123,7 +123,7 @@ Each Manager specifies additional parameters which are used only when the Manage
             "hosthome_mount": false,
             "shared_mount": true
         }
-  
+
 Example of the default `kathara.conf`(5) file using Docker Manager.
 
 m4_include(footer.txt)

--- a/src/Resources/model/Machine.py
+++ b/src/Resources/model/Machine.py
@@ -210,6 +210,12 @@ class Machine(object):
                                                                                          complete_osx_command))
 
                 TMUX.get_instance().add_window(self.lab.name, self.name, complete_osx_command, cwd=self.lab.path)
+            elif terminal == "iTerm":
+                import appscript
+                logging.debug("Opening iTerm with command: %s." % complete_osx_command)
+                iterm = appscript.app('iTerm')
+                window = iterm.create_window_with_default_profile()
+                window.current_session.write(text=complete_osx_command)
             else:
                 import appscript
                 logging.debug("Opening OSX terminal with command: %s." % complete_osx_command)

--- a/src/Resources/setting/Setting.py
+++ b/src/Resources/setting/Setting.py
@@ -187,7 +187,18 @@ class Setting(object):
         def check_unix():
             return os.path.isfile(terminal) and os.access(terminal, os.X_OK)
 
-        if not utils.exec_by_platform(check_unix, lambda: True, lambda: True):
+        def check_macos():
+            if terminal == "iTerm":
+                import appscript
+                import aem
+                try:
+                    appscript.app('iTerm')
+                except aem.findapp.ApplicationNotFoundError:
+                    return False
+
+            return True
+
+        if not utils.exec_by_platform(check_unix, lambda: True, check_macos):
             raise SettingsError("Terminal Emulator `%s` not valid! Install it before using it." % terminal)
 
         return True


### PR DESCRIPTION
Added AppleScript integration for iTerm using `appscript` which is already used.