### PR TITLE
AUR PKGBUILD: add Resources folder

### DIFF
--- a/scripts/Linux-Pkg/pkginfo/PKGBUILD
+++ b/scripts/Linux-Pkg/pkginfo/PKGBUILD
@@ -42,6 +42,8 @@ package() {
   cp -r manpages/* $pkgdir/usr/share/man/
   install -d -m 755 $pkgdir/etc/bash_completion.d/
   install -p -m 644 kathara.bash-completion $pkgdir/etc/bash_completion.d/
+  install -d -m 755 $pkgdir/usr/lib/$pkgname/Resources
+  cp -r Resources/* $pkgdir/usr/lib/$pkgname/Resources/
   mkdir $pkgdir/usr/bin
   ln -sf /usr/lib/$pkgname/kathara "$pkgdir/usr/bin/$pkgname"
 }


### PR DESCRIPTION
**- What I did**
Added the Resource folder installation in the PKGBUILD to also have plugins installed (I noticed while trying the Tmux integration which was not working because Kathara couldn't find the libtmux script).

**- How I did it**
See the diff.

**- How to verify it**
Install Kathara from AUR, edit the `kathara.conf` to use ` "terminal": "TMUX",` and run `kathara lstart` into a lab folder: observe the error.
Then install Kathara with the provided PKGBUILD and see that it works.

**- Description for the changelog**
AUR PKGBUILD: add Resources folder

PS: it seems that the Tmux integration is not documented, can you please provide users proper instructions on how to use it?
