### PR TITLE
Simple changes on the road to multiarch support (hello ARM64)

### DIFF
--- a/scripts/Linux-Deb/debian/control
+++ b/scripts/Linux-Deb/debian/control
@@ -14,7 +14,7 @@ Vcs-Browser: https://github.com/KatharaFramework/Kathara
 Homepage: https://www.kathara.org/
 
 Package: kathara
-Architecture: amd64
+Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Suggests: docker.io (>= 17.03.2) | docker-ce (>= 17.03.2), xterm
 Description: Lightweight network emulation tool.

--- a/src/Resources/manager/docker/DockerLink.py
+++ b/src/Resources/manager/docker/DockerLink.py
@@ -7,7 +7,6 @@ import docker
 import progressbar
 from docker import types
 
-from ..docker.DockerPlugin import PLUGIN_NAME
 from ... import utils
 from ...exceptions import PrivilegeError
 from ...model.Link import BRIDGE_LINK_NAME
@@ -72,7 +71,7 @@ class DockerLink(object):
         network_ipam_config = docker.types.IPAMConfig(driver='null')
 
         link.api_object = self.client.networks.create(name=link_name,
-                                                      driver=PLUGIN_NAME,
+                                                      driver=Setting.get_instance().plugin_name,
                                                       check_duplicate=True,
                                                       ipam=network_ipam_config,
                                                       labels={"lab_hash": link.lab.folder_hash,

--- a/src/Resources/manager/docker/DockerPlugin.py
+++ b/src/Resources/manager/docker/DockerPlugin.py
@@ -4,8 +4,8 @@ from docker.errors import NotFound
 
 from ... import utils
 from ...os.Networking import Networking
+from ...setting.Setting import Setting
 
-PLUGIN_NAME = "kathara/katharanp:latest"
 XTABLES_CONFIGURATION_KEY = "xtables_lock"
 XTABLES_LOCK_PATH = "/run/xtables.lock"
 
@@ -18,21 +18,21 @@ class DockerPlugin(object):
 
     def check_and_download_plugin(self):
         try:
-            logging.debug("Checking plugin `%s`..." % PLUGIN_NAME)
+            logging.debug("Checking plugin `%s`..." % Setting.get_instance().plugin_name)
 
-            plugin = self.client.plugins.get(PLUGIN_NAME)
+            plugin = self.client.plugins.get(Setting.get_instance().plugin_name)
             # Check for plugin updates.
             plugin.upgrade()
         except NotFound:
             logging.info("Installing Kathara Network Plugin...")
-            plugin = self.client.plugins.install(PLUGIN_NAME)
+            plugin = self.client.plugins.install(Setting.get_instance().plugin_name)
             logging.info("Kathara Network Plugin installed successfully!")
 
         xtables_lock_mount = self._get_xtables_lock_mount()
         if not plugin.enabled:
             self._configure_xtables_mount(plugin, xtables_lock_mount)
 
-            logging.debug("Enabling plugin `%s`..." % PLUGIN_NAME)
+            logging.debug("Enabling plugin `%s`..." % Setting.get_instance().plugin_name)
             plugin.enable()
         else:
             # Get the mount of xtables.lock from the current plugin configuration
@@ -45,7 +45,7 @@ class DockerPlugin(object):
 
                 self._configure_xtables_mount(plugin, xtables_lock_mount)
 
-                logging.debug("Enabling plugin `%s`..." % PLUGIN_NAME)
+                logging.debug("Enabling plugin `%s`..." % Setting.get_instance().plugin_name)
                 plugin.enable()
 
     def _get_xtables_lock_mount(self):

--- a/src/Resources/setting/Setting.py
+++ b/src/Resources/setting/Setting.py
@@ -15,7 +15,7 @@ AVAILABLE_MANAGERS = ["docker", "kubernetes"]
 ONE_WEEK = 604800
 
 DEFAULTS = {
-    "plugin_name": 'kathara/katharanp:latest',
+    "plugin_name": 'kathara/katharanp:' + utils.arch(),
     "image": 'kathara/quagga',
     "manager_type": 'docker',
     "terminal": utils.exec_by_platform(lambda: '/usr/bin/xterm', lambda: '', lambda: 'Terminal'),
@@ -28,10 +28,11 @@ DEFAULTS = {
     "enable_ipv6": False
 }
 
+SETTING_KEYS = list(DEFAULTS.keys())  + ['last_checked']
+
 
 class Setting(object):
-    __slots__ = ['plugin_name', 'image', 'manager_type', 'terminal', 'open_terminals', 'device_shell', 'net_prefix',
-                 'device_prefix', 'debug_level', 'print_startup_log', 'enable_ipv6', 'last_checked', 'addons']
+    __slots__ = SETTING_KEYS + ['addons']
 
     SETTING_FOLDER = None
     SETTING_PATH = None
@@ -205,15 +206,7 @@ class Setting(object):
         self.addons = SettingsAddonFactory().create_instance(class_args=(self.manager_type.capitalize(), ))
 
     def _to_dict(self):
-        return {"image": self.image,
-                "manager_type": self.manager_type,
-                "terminal": self.terminal,
-                "open_terminals": self.open_terminals,
-                "device_shell": self.device_shell,
-                "net_prefix": self.net_prefix,
-                "device_prefix": self.device_prefix,
-                "debug_level": self.debug_level,
-                "print_startup_log": self.print_startup_log,
-                "enable_ipv6": self.enable_ipv6,
-                "last_checked": self.last_checked,
-                }
+        res = {}
+        for key in SETTING_KEYS:
+            res[key] = getattr(self, key)
+        return res

--- a/src/Resources/setting/Setting.py
+++ b/src/Resources/setting/Setting.py
@@ -15,6 +15,7 @@ AVAILABLE_MANAGERS = ["docker", "kubernetes"]
 ONE_WEEK = 604800
 
 DEFAULTS = {
+    "plugin_name": 'kathara/katharanp:latest',
     "image": 'kathara/quagga',
     "manager_type": 'docker',
     "terminal": utils.exec_by_platform(lambda: '/usr/bin/xterm', lambda: '', lambda: 'Terminal'),
@@ -29,7 +30,7 @@ DEFAULTS = {
 
 
 class Setting(object):
-    __slots__ = ['image', 'manager_type', 'terminal', 'open_terminals', 'device_shell', 'net_prefix',
+    __slots__ = ['plugin_name', 'image', 'manager_type', 'terminal', 'open_terminals', 'device_shell', 'net_prefix',
                  'device_prefix', 'debug_level', 'print_startup_log', 'enable_ipv6', 'last_checked', 'addons']
 
     SETTING_FOLDER = None

--- a/src/Resources/utils.py
+++ b/src/Resources/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import importlib
 import math
 import os
+import platform
 import re
 import shutil
 import sys
@@ -252,3 +253,11 @@ def is_excluded_file(path):
     _, filename = os.path.split(path)
 
     return filename in EXCLUDED_FILES
+
+
+# Architecture test
+def arch():
+    if platform.machine() in ['arm64', 'aarch64']:
+        return 'arm64'
+    else:
+        return 'amd64'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/KatharaFramework/Kathara/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
On the road to add Apple M1 ARM64 support both under Debian based OS and macOS (first contribution to fix #104). With small changes I managed to build and run ARM64 Kathará images on Ubuntu 20 with a proper `.deb` generated with the Linux-Deb script. Under macOS, the proof of concept works, one can run kathará through python directly (unfortunately pyinstaller is not properly working yet). 

My system is a Macbook Pro M1 laptop running macOS 11.4. Ubuntu 20 is running natively inside an UTM virtual machine.

Notice that this is only part of the solution, all the Kathará docker images have to be rebuilt for ARM64, including the `NetworkPlugin` image. I plan to open issues in the proper repositories.

**- How I did it**
1) change Architecture in the control file from `amd64` to `any` so that it built an ARM64 `.deb` from Ubuntu with `make docker-unsigned`
2) moved `PLUGIN_NAME` from a constant inside https://github.com/KatharaFramework/Kathara/blob/b4b44d3f1af3130cf9212fbdc4e1548ec94ab1da/src/Resources/manager/docker/DockerPlugin.py#L8 into a `plugin_name` setting in the `kathara.conf` file to permit a selection per architecture.

**- How to verify it**
Under ARM64 Ubuntu 20:
1) use `make docker-unsigned` inside `scripts/Linux-Deb/` to compile and then install `scripts/Linux-Deb/Output/kathara_3.1.0-1focal_amd64.deb` with `dpkg`
2) modify your `kathara.conf` file to have `plugin_name` and `image` point to ARM64 images, for example:
```
 "plugin_name": "nopid/katharanp:latest",
 "image": "nopid/quagga:debian10",
```
3) Enjoy Kathará! (tested with 2 vstart machines on a same hub and with some labs from `Kathara-Labs`)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
better multiarch support: build deb to any architecture, add plugin_name to settings