### PR TITLE
Network plugin

### DIFF
--- a/src/Kathara/manager/docker/DockerLink.py
+++ b/src/Kathara/manager/docker/DockerLink.py
@@ -10,7 +10,7 @@ import progressbar
 from docker import DockerClient
 from docker import types
 
-from ..docker.DockerPlugin import PLUGIN_NAME
+#from ..docker.DockerPlugin import PLUGIN_NAME
 from ... import utils
 from ...exceptions import PrivilegeError
 from ...model.ExternalLink import ExternalLink
@@ -109,7 +109,7 @@ class DockerLink(object):
 
             user_label = "shared_cd" if Setting.get_instance().shared_cd else utils.get_current_user_name()
             link.api_object = self.client.networks.create(name=link_name,
-                                                          driver=PLUGIN_NAME,
+                                                          driver=Setting.get_instance.plugin,
                                                           check_duplicate=True,
                                                           ipam=network_ipam_config,
                                                           labels={"lab_hash": link.lab.hash,

--- a/src/Kathara/manager/docker/DockerPlugin.py
+++ b/src/Kathara/manager/docker/DockerPlugin.py
@@ -1,5 +1,4 @@
 import logging
-import platform
 from typing import Callable
 
 from docker import DockerClient

--- a/src/Kathara/manager/docker/DockerPlugin.py
+++ b/src/Kathara/manager/docker/DockerPlugin.py
@@ -9,7 +9,6 @@ from ... import utils
 from ...os.Networking import Networking
 from ...setting.Setting import Setting
 
-PLUGIN_NAME = "kathara/katharanp"
 XTABLES_CONFIGURATION_KEY = "xtables_lock"
 XTABLES_LOCK_PATH = "/run/xtables.lock"
 
@@ -20,7 +19,6 @@ class DockerPlugin(object):
 
     def __init__(self, client: DockerClient):
         self.client: DockerClient = client
-        self.plugin_name_arch = "%s:%s" % (PLUGIN_NAME, self._getArchitecture())
 
     def check_and_download_plugin(self) -> None:
         """Check the presence of the Kathara Network Plugin and download it or upgrade it, if needed.
@@ -28,6 +26,8 @@ class DockerPlugin(object):
         Returns:
             None
         """
+        self.plugin_name_arch = Setting.get_instance().plugin
+
         try:
             logging.debug("Checking plugin `%s`..." % self.plugin_name_arch)
             plugin = self.client.plugins.get(self.plugin_name_arch)
@@ -79,17 +79,3 @@ class DockerPlugin(object):
         plugin.configure({
             XTABLES_CONFIGURATION_KEY + '.source': xtables_lock_mount
         })
-
-    @staticmethod
-    def _getArchitecture():
-        machine = platform.uname().machine
-        arch = ""
-        if machine == "x86_64" or machine == "AMD64":
-            arch = "amd64"
-        elif machine == "i686":
-            arch = "386"
-        elif machine == "aarch64":
-            arch = "arm64"
-        elif machine == "armv7l" or machine == "armv6l":
-            arch = "arm"
-        return arch

--- a/src/Kathara/manager/docker/DockerPlugin.py
+++ b/src/Kathara/manager/docker/DockerPlugin.py
@@ -15,7 +15,7 @@ XTABLES_LOCK_PATH = "/run/xtables.lock"
 
 class DockerPlugin(object):
     """Class responsible for interacting with Docker Plugins."""
-    __slots__ = ['client', 'plugin_name_arch']
+    __slots__ = ['client', 'plugin_name']
 
     def __init__(self, client: DockerClient):
         self.client: DockerClient = client
@@ -26,17 +26,17 @@ class DockerPlugin(object):
         Returns:
             None
         """
-        self.plugin_name_arch = Setting.get_instance().plugin
+        self.plugin_name = Setting.get_instance().plugin
 
         try:
-            logging.debug("Checking plugin `%s`..." % self.plugin_name_arch)
-            plugin = self.client.plugins.get(self.plugin_name_arch)
+            logging.debug("Checking plugin `%s`..." % self.plugin_name)
+            plugin = self.client.plugins.get(self.plugin_name)
             # Check for plugin updates.
             plugin.upgrade()
         except NotFound:
             if Setting.get_instance().remote_url is None:
                 logging.info("Installing Kathara Network Plugin...")
-                plugin = self.client.plugins.install(self.plugin_name_arch)
+                plugin = self.client.plugins.install(self.plugin_name)
                 logging.info("Kathara Network Plugin installed successfully!")
             else:
                 raise Exception("Kathara Network Plugin not found on remote Docker connection.")
@@ -45,7 +45,7 @@ class DockerPlugin(object):
             xtables_lock_mount = self._get_xtables_lock_mount()
             if not plugin.enabled:
                 self._configure_xtables_mount(plugin, xtables_lock_mount)
-                logging.debug("Enabling plugin `%s`..." % self.plugin_name_arch)
+                logging.debug("Enabling plugin `%s`..." % self.plugin_name)
                 plugin.enable()
             else:
                 # Get the mount of xtables.lock from the current plugin configuration
@@ -56,7 +56,7 @@ class DockerPlugin(object):
                 if mount_obj["Source"] != xtables_lock_mount:
                     plugin.disable()
                     self._configure_xtables_mount(plugin, xtables_lock_mount)
-                    logging.debug("Enabling plugin `%s`..." % self.plugin_name_arch)
+                    logging.debug("Enabling plugin `%s`..." % self.plugin_name)
                     plugin.enable()
         else:
             if not plugin.enabled:

--- a/src/Kathara/manager/docker/DockerPlugin.py
+++ b/src/Kathara/manager/docker/DockerPlugin.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 from typing import Callable
 
 from docker import DockerClient
@@ -8,7 +9,8 @@ from ... import utils
 from ...os.Networking import Networking
 from ...setting.Setting import Setting
 
-PLUGIN_NAME = "kathara/katharanp:latest"
+# Create Plugins on Dockerhub with :{arch}
+PLUGIN_NAME = ("kathara/katharanp:%s" % DockerPlugin.getArchitecture())
 XTABLES_CONFIGURATION_KEY = "xtables_lock"
 XTABLES_LOCK_PATH = "/run/xtables.lock"
 
@@ -77,3 +79,17 @@ class DockerPlugin(object):
         plugin.configure({
             XTABLES_CONFIGURATION_KEY + '.source': xtables_lock_mount
         })
+
+    @staticmethod
+    def getArchitecture():
+        machine = platform.uname().machine
+        arch = ""
+        if machine == "x86_64" or machine == "AMD64":
+            arch = "amd64"
+        elif machine == "i686":
+            arch = "386"
+        elif machine == "aarch64":
+            arch = "arm64"
+        elif machine == "armv7l" or machine == "armv6l":
+            arch = "arm"
+        return arch

--- a/src/Kathara/manager/docker/DockerPlugin.py
+++ b/src/Kathara/manager/docker/DockerPlugin.py
@@ -16,7 +16,7 @@ XTABLES_LOCK_PATH = "/run/xtables.lock"
 
 class DockerPlugin(object):
     """Class responsible for interacting with Docker Plugins."""
-    __slots__ = ['client']
+    __slots__ = ['client', 'plugin_name_arch']
 
     def __init__(self, client: DockerClient):
         self.client: DockerClient = client

--- a/src/Kathara/setting/Setting.py
+++ b/src/Kathara/setting/Setting.py
@@ -28,7 +28,8 @@ DEFAULTS = {
     "device_prefix": 'kathara',
     "debug_level": 'INFO',
     "print_startup_log": True,
-    "enable_ipv6": False
+    "enable_ipv6": False,
+    "plugin": 'kathara/katharanp:%s-latest' % utils.getArchitecture()
 }
 
 
@@ -36,7 +37,7 @@ class Setting(object):
     """Class responsible for interacting with Kathara Settings."""
 
     __slots__ = ['image', 'manager_type', 'terminal', 'open_terminals', 'device_shell', 'net_prefix',
-                 'device_prefix', 'debug_level', 'print_startup_log', 'enable_ipv6', 'last_checked', 'addons']
+                 'device_prefix', 'debug_level', 'print_startup_log', 'enable_ipv6', 'last_checked', 'addons', 'plugin']
 
     SETTING_FOLDER: str = None
     SETTING_PATH: str = None
@@ -280,4 +281,5 @@ class Setting(object):
                 "print_startup_log": self.print_startup_log,
                 "enable_ipv6": self.enable_ipv6,
                 "last_checked": self.last_checked,
+                "plugin": self.plugin
                 }

--- a/src/Kathara/utils.py
+++ b/src/Kathara/utils.py
@@ -13,7 +13,7 @@ import tempfile
 from io import BytesIO
 from itertools import islice
 from multiprocessing import cpu_count
-from platform import node
+from platform import node, machine
 from sys import platform as _platform
 from typing import Any, Optional, Match, Generator, List, Callable, Union, Dict, Iterable
 
@@ -291,3 +291,19 @@ def is_excluded_file(path: str) -> bool:
     _, filename = os.path.split(path)
 
     return filename in EXCLUDED_FILES
+
+def getArchitecture():
+    architecture = str.lower(machine())
+    logging.debug("Identifying machine architecture: %s" % architecture)
+    if architecture == "x86_64" or architecture == "amd64":
+        return "amd64"
+    elif architecture == "i686":
+        return "386"
+    elif architecture == "aarch64" or architecture == "arm64":
+        return "arm64v8"
+    elif architecture == "armv7l":
+        return "armv7"
+    elif architecture == "armv6l":
+        return "armv6"
+    else:
+        return "Not implemented for %s" % architecture


### PR DESCRIPTION
**- What I did**
Improved the Network Plugin usage to be Multiarchitecture capable. Therefore, consider the naming scheme for the Network Plugin proposed in [PR7](https://github.com/KatharaFramework/NetworkPlugin/pull/7). Moreover, it is now easily editable over the config file, if needed. 

**- How I did it**
I removed the PLUGIN_NAME variable in `DockerPlugin.py` and added it to the Settings dictionary.

**- How to verify it**
As long as the network plugin is not rebuilt, add the `"plugin": "kathara/katharanp:latest"` to the kathara configuration file.

**- Description for the changelog**
Multiarchitecture support for the Network Plugin and enhanced configurability for the used Network Plugin image.
