### PR TITLE
Update Machine.py

### DIFF
--- a/src/Kathara/model/Machine.py
+++ b/src/Kathara/model/Machine.py
@@ -152,7 +152,7 @@ class Machine(object):
             return
 
         if name == "env":
-            matches = re.search(r"^(?P<key>\w+)=(?P<value>\w+)$", value)
+            matches = re.search(r"^(?P<key>\w+)=(?P<value>\S+)$", value)
 
             # Check for valid kv-pair
             if matches:


### PR DESCRIPTION
Replaced Regex from `w+` to `S+`, such that environment variables like `ONOS_APPS=org.onosproject.openflow,org,onosproject.gui2` can be added with ease.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/KatharaFramework/Kathara/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I created a ONOS controller, which can be configured via environment variables like `ONOS_APPS=org.onosproject.openflow,org.onosproject.gui2`. Unfortunately, the current regex in `model.Machine.py` does only allow `w+` as variable.

**- How I did it**
I replaced `w+` with `S+` to be able to add the variables

**- How to verify it**
Create an environment variable, which contains more than only alphanumerical values and add it to the container.

**- Description for the changelog**
Environment variables can now contain all non-space characters.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
