### PR TITLE
Deprecation Warnings of libtmux

### DIFF
--- a/src/Kathara/trdparty/libtmux/tmux.py
+++ b/src/Kathara/trdparty/libtmux/tmux.py
@@ -71,7 +71,7 @@ class TMUX(object):
 
     def _get_session_from_server(self, session_name):
         if self._server.has_session(session_name):
-            return self._server.sessions.get(session_name=session_name})
+            return self._server.sessions.get(session_name=session_name)
 
         return None
 

--- a/src/Kathara/trdparty/libtmux/tmux.py
+++ b/src/Kathara/trdparty/libtmux/tmux.py
@@ -31,7 +31,7 @@ class TMUX(object):
         initial_window_name = "%008x" % random.getrandbits(32)
         session, added = self.add_session(session_name, initial_window_name)
 
-        machine_window = session.find_where({"window_name": machine_name})
+        machine_window = session.windows.get(window_name=machine_name, default=None)
         if not machine_window:
             logging.debug("Starting TMUX window for `%s`..." % machine_name)
             session.new_window(window_name=machine_name, window_shell=shell, start_directory=cwd)
@@ -54,7 +54,7 @@ class TMUX(object):
 
         logging.debug("Initialized TMUX session %s" % session_name)
 
-        session = self._server.find_where({"session_name": session_name})
+        session = self._server.sessions.get(session_name=session_name)
         self.add_session_by_name(session_name, session)
 
         return session, True
@@ -71,13 +71,13 @@ class TMUX(object):
 
     def _get_session_from_server(self, session_name):
         if self._server.has_session(session_name):
-            return self._server.find_where({"session_name": session_name})
+            return self._server.sessions.get(session_name=session_name})
 
         return None
 
     @staticmethod
     def kill_window(session, window_name):
-        window = session.find_where({"window_name": window_name})
+        window = session.windows.get(window_name=window_name, default=None)
 
         if window:
             window.kill_window()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,7 +8,7 @@ slug>=2.0;
 deepdiff==6.2.2;
 pyroute2==0.5.19;
 progressbar2>=1.14.0;
-libtmux>=0.8.2; sys_platform == 'darwin' or sys_platform == 'linux'
+libtmux>=0.18.0; sys_platform == 'darwin' or sys_platform == 'linux'
 git+https://github.com/saghul/pyuv@master#egg=pyuv
 appscript>=1.1.0; sys_platform == 'darwin'
 pypiwin32>=223; sys_platform == 'win32'


### PR DESCRIPTION
**- What I did**
When starting Kathara with tmux, the following deprecation notices are issued
/usr/lib/kathara/libtmux/server.py:633: UserWarning: Server.find_where() is deprecated
/usr/lib/kathara/libtmux/session.py:635: UserWarning: Session.find_where() is deprecated

**- How I did it**
Replaced deprecated functions by the new ones found in libtmux [changelog](https://github.com/tmux-python/libtmux/blob/master/CHANGES)

**- How to verify it**
Starting Kathara with tmux, should not show deprecation notices anymore

**- Description for the changelog**
Solved deprecation for *libtmux* `find_where()` functions.
