### PR TITLE
Add support for private registry on Megalos

### DIFF
--- a/src/Kathara/cli/ui/setting/KubernetesOptionsHandler.py
+++ b/src/Kathara/cli/ui/setting/KubernetesOptionsHandler.py
@@ -153,44 +153,41 @@ class KubernetesOptionsHandler(OptionsHandler):
 
         image_pull_policy_item = SubmenuItem(image_pull_policy_string, image_pull_policy_menu, current_menu)
 
-        # Private Registry dockerconfigjson Option
-        pr_dcj_string = "Private Registry Docker Configuration"
-        pr_dcj_menu = SelectionMenu(
+        # Private Registry docker_config_json Option
+        docker_config_json_string = "Private Registry Configuration"
+        docker_config_json_menu = SelectionMenu(
             strings=[],
-            title=pr_dcj_string,
-            prologue_text="""Add a base64-encoded Docker configuration string to """
-                          """access private container registries. It will be used """
-                          """to create a Kubernetes secret of type `kubernetes.io/dockerconfigjson`.
-
-                          Default is %s.""" % DEFAULTS['private_registry_dockerconfigjson'],
+            title=docker_config_json_string,
+            subtitle=setting_utils.current_enabled("docker_config_json"),
+            prologue_text="""Insert the config.json file path containing the configuration to """
+                          """access private container registries. The content will be stored as """
+                          """a base64 string and it will be used to create a Kubernetes Secret """
+                          """of type `kubernetes.io/dockerconfigjson`.   
+                          
+                          Default is %s.""" % DEFAULTS['docker_config_json'],
             formatter=menu_formatter
         )
 
-        pr_dcj_menu.append_item(
+        docker_config_json_menu.append_item(
             FunctionItem(
-                text=pr_dcj_string,
-                function=setting_utils.read_value,
-                args=['private_registry_dockerconfigjson',
-                      RegexValidator(r'.*'),
-                      'Write a base64-encoded Docker configuration string:',
-                      'Docker configuration string not valid!'
-                      ],
+                text=docker_config_json_string,
+                function=setting_utils.read_docker_config_json,
                 should_exit=True
             )
         )
-        pr_dcj_menu.append_item(
+        docker_config_json_menu.append_item(
             FunctionItem(
                 text="Reset value to Empty String",
                 function=setting_utils.update_setting_value,
-                args=["private_registry_dockerconfigjson", None],
+                args=["docker_config_json", None],
                 should_exit=True
             )
         )
 
-        pr_dcj_item = SubmenuItem(pr_dcj_string, pr_dcj_menu, current_menu)
+        docker_config_json_item = SubmenuItem(docker_config_json_string, docker_config_json_menu, current_menu)
 
         current_menu.append_item(api_url_item)
         current_menu.append_item(api_token_item)
         current_menu.append_item(host_shared_item)
         current_menu.append_item(image_pull_policy_item)
-        current_menu.append_item(pr_dcj_item)
+        current_menu.append_item(docker_config_json_item)

--- a/src/Kathara/cli/ui/setting/KubernetesOptionsHandler.py
+++ b/src/Kathara/cli/ui/setting/KubernetesOptionsHandler.py
@@ -153,7 +153,44 @@ class KubernetesOptionsHandler(OptionsHandler):
 
         image_pull_policy_item = SubmenuItem(image_pull_policy_string, image_pull_policy_menu, current_menu)
 
+        # Private Registry dockerconfigjson Option
+        pr_dcj_string = "Private Registry Docker Configuration"
+        pr_dcj_menu = SelectionMenu(
+            strings=[],
+            title=pr_dcj_string,
+            prologue_text="""Add a base64-encoded Docker configuration string to """
+                          """access private container registries. It will be used """
+                          """to create a Kubernetes secret of type `kubernetes.io/dockerconfigjson`.
+
+                          Default is %s.""" % DEFAULTS['private_registry_dockerconfigjson'],
+            formatter=menu_formatter
+        )
+
+        pr_dcj_menu.append_item(
+            FunctionItem(
+                text=pr_dcj_string,
+                function=setting_utils.read_value,
+                args=['private_registry_dockerconfigjson',
+                      RegexValidator(r'.*'),
+                      'Write a base64-encoded Docker configuration string:',
+                      'Docker configuration string not valid!'
+                      ],
+                should_exit=True
+            )
+        )
+        pr_dcj_menu.append_item(
+            FunctionItem(
+                text="Reset value to Empty String",
+                function=setting_utils.update_setting_value,
+                args=["private_registry_dockerconfigjson", None],
+                should_exit=True
+            )
+        )
+
+        pr_dcj_item = SubmenuItem(pr_dcj_string, pr_dcj_menu, current_menu)
+
         current_menu.append_item(api_url_item)
         current_menu.append_item(api_token_item)
         current_menu.append_item(host_shared_item)
         current_menu.append_item(image_pull_policy_item)
+        current_menu.append_item(pr_dcj_item)

--- a/src/Kathara/exceptions.py
+++ b/src/Kathara/exceptions.py
@@ -172,3 +172,13 @@ class DockerPluginError(Exception):
 # Kubernetes Exceptions
 class KubernetesConfigMapError(Exception):
     pass
+
+
+class InvalidDockerConfigJSONError(ValueError):
+    __slots__ = ['docker_config_json_path']
+
+    def __init__(self, docker_config_json_path: str):
+        self.docker_config_json_path: str = docker_config_json_path
+
+    def __str__(self):
+        return f"Invalid Docker Config JSON file: {self.docker_config_json_path}"

--- a/src/Kathara/exceptions.py
+++ b/src/Kathara/exceptions.py
@@ -174,7 +174,7 @@ class KubernetesConfigMapError(Exception):
     pass
 
 
-class InvalidDockerConfigJSONError(ValueError):
+class InvalidDockerConfigJsonError(ValueError):
     __slots__ = ['docker_config_json_path']
 
     def __init__(self, docker_config_json_path: str):

--- a/src/Kathara/manager/kubernetes/KubernetesMachine.py
+++ b/src/Kathara/manager/kubernetes/KubernetesMachine.py
@@ -458,11 +458,17 @@ class KubernetesMachine(object):
                 )
             ))
 
+        # Add image_pull_secrets if using a private registry
+        image_pull_secrets_arg = {}
+        if Setting.get_instance().private_registry_dockerconfigjson:
+            image_pull_secrets_arg = {"image_pull_secrets": [client.V1LocalObjectReference(name="private-registry")]}
+
         pod_spec = client.V1PodSpec(containers=[container_definition],
                                     hostname=machine.meta['real_name'],
                                     dns_policy="None",
                                     dns_config=dns_config,
-                                    volumes=volumes
+                                    volumes=volumes,
+                                    **image_pull_secrets_arg
                                     )
 
         pod_template = client.V1PodTemplateSpec(metadata=pod_metadata, spec=pod_spec)

--- a/src/Kathara/manager/kubernetes/KubernetesMachine.py
+++ b/src/Kathara/manager/kubernetes/KubernetesMachine.py
@@ -21,6 +21,7 @@ from kubernetes.watch import watch
 
 from .KubernetesConfigMap import KubernetesConfigMap
 from .KubernetesNamespace import KubernetesNamespace
+from .KubernetesSecret import DOCKERCONFIGJSON_SECRET_NAME
 from .stats.KubernetesMachineStats import KubernetesMachineStats
 from ... import utils
 from ...event.EventDispatcher import EventDispatcher
@@ -458,10 +459,11 @@ class KubernetesMachine(object):
                 )
             ))
 
-        # Add image_pull_secrets if using a private registry
+        # Add image_pull_secrets if using private registries
         image_pull_secrets_arg = {}
-        if Setting.get_instance().private_registry_dockerconfigjson:
-            image_pull_secrets_arg = {"image_pull_secrets": [client.V1LocalObjectReference(name="private-registry")]}
+        if Setting.get_instance().docker_config_json:
+            image_pull_secrets_arg = {"image_pull_secrets":
+                                          [client.V1LocalObjectReference(name=DOCKERCONFIGJSON_SECRET_NAME)]}
 
         pod_spec = client.V1PodSpec(containers=[container_definition],
                                     hostname=machine.meta['real_name'],

--- a/src/Kathara/manager/kubernetes/KubernetesManager.py
+++ b/src/Kathara/manager/kubernetes/KubernetesManager.py
@@ -305,6 +305,7 @@ class KubernetesManager(IManager):
         if all_users:
             logging.warning("User-specific options have no effect on Megalos.")
 
+        self.k8s_secret.wipe()
         self.k8s_namespace.wipe()
 
     def connect_tty(self, machine_name: str, lab_hash: Optional[str] = None, lab_name: Optional[str] = None,

--- a/src/Kathara/manager/kubernetes/KubernetesManager.py
+++ b/src/Kathara/manager/kubernetes/KubernetesManager.py
@@ -10,6 +10,7 @@ from .KubernetesConfig import KubernetesConfig
 from .KubernetesLink import KubernetesLink
 from .KubernetesMachine import KubernetesMachine
 from .KubernetesNamespace import KubernetesNamespace
+from .KubernetesSecret import KubernetesSecret
 from .stats.KubernetesLinkStats import KubernetesLinkStats
 from .stats.KubernetesMachineStats import KubernetesMachineStats
 from ... import utils
@@ -25,12 +26,13 @@ from ...utils import pack_files_for_tar, check_required_single_not_none_var, che
 class KubernetesManager(IManager):
     """Class responsible for interacting with Kubernetes API."""
 
-    __slots__ = ['k8s_namespace', 'k8s_machine', 'k8s_link']
+    __slots__ = ['k8s_secret', 'k8s_namespace', 'k8s_machine', 'k8s_link']
 
     def __init__(self) -> None:
         KubernetesConfig.load_kube_config()
 
-        self.k8s_namespace: KubernetesNamespace = KubernetesNamespace()
+        self.k8s_secret: KubernetesSecret = KubernetesSecret()
+        self.k8s_namespace: KubernetesNamespace = KubernetesNamespace(self.k8s_secret)
         self.k8s_machine: KubernetesMachine = KubernetesMachine(self.k8s_namespace)
         self.k8s_link: KubernetesLink = KubernetesLink(self.k8s_namespace)
 

--- a/src/Kathara/manager/kubernetes/KubernetesNamespace.py
+++ b/src/Kathara/manager/kubernetes/KubernetesNamespace.py
@@ -68,8 +68,6 @@ class KubernetesNamespace(object):
         for namespace in namespaces:
             self.client.delete_namespace(namespace.metadata.name)
 
-        self.kubernetes_secret.wipe()
-
         self._wait_namespaces_deletion(label_selector="app=kathara")
 
     def get_all(self) -> Iterable[client.V1Namespace]:

--- a/src/Kathara/manager/kubernetes/KubernetesSecret.py
+++ b/src/Kathara/manager/kubernetes/KubernetesSecret.py
@@ -1,0 +1,108 @@
+import logging
+from typing import Optional, Iterable
+
+from kubernetes import client, watch
+from kubernetes.client.api import core_v1_api
+from kubernetes.client.rest import ApiException
+
+from ...setting.Setting import Setting
+from ...model.Lab import Lab
+
+DOCKERCONFIGJSON_SECRET_NAME = 'private-registry'
+
+class KubernetesSecret(object):
+    """Class responsible for interacting with Kubernetes secrets."""
+
+    __slots__ = ['client']
+
+    def __init__(self) -> None:
+        self.client: core_v1_api.CoreV1Api = core_v1_api.CoreV1Api()
+
+    def create_dockerconfigjson_secret(self, lab_hash: str, name: str,
+                                       docker_config_json: str) -> Optional[client.V1Secret]:
+        """Return a Kubernetes secret of type kubernetes.io/dockerconfigjson from a Kathara network scenario.
+
+        Args:
+            lab_hash (str): The hash of a Kathara network scenario.
+            name (str): The name of the secret.
+            docker_config_json (str): A Docker configuration JSON.
+
+        Returns:
+            Optional[client.V1Secret]: The Kubernetes secret for the Docker configuration JSON.
+        """
+        secret_definition = client.V1Secret(
+            metadata=client.V1ObjectMeta(name=name, namespace=lab_hash, labels={'app': 'kathara'}),
+            type="kubernetes.io/dockerconfigjson",
+            data={".dockerconfigjson": docker_config_json}
+        )
+
+        try:
+            self.client.create_namespaced_secret(lab_hash, secret_definition)
+            self._wait_secret_creation(lab_hash, name)
+        except ApiException:
+            return None
+
+    def delete(self, lab_hash: str, name: str) -> None:
+        """Delete the Kubernetes secret corresponding to the lab_hash.
+
+        Args:
+            lab_hash (str): The hash of a Kathara network scenario.
+            name (str): The name of the secret.
+
+        Returns:
+            None
+        """
+        try:
+            self.client.delete_namespaced_secret(name, lab_hash)
+            self._wait_secrets_deletion(lab_hash, field_selector=f"metadata.name={name}")
+        except ApiException:
+            return
+
+    def wipe(self) -> None:
+        """Namespace deletion implies automatic deletion of all secrets.
+
+        Returns:
+            None
+        """
+        pass
+
+    def _wait_secret_creation(self, lab_hash: str, name: str) -> None:
+        """Wait for the secret creation to be completed.
+
+        Args:
+            lab_hash (str): The hash of a Kathara network scenario.
+            name (str): The name of the secret.
+
+        Returns:
+            None
+        """
+        w = watch.Watch()
+        for event in w.stream(self.client.list_namespaced_secret, namespace=lab_hash, field_selector=f"metadata.name={name}"):
+            logging.debug(f"Event: {event['type']} - Secret: {event['object'].metadata.name}")
+
+            if event['type'] == "ADDED":
+                break
+
+    def _wait_secrets_deletion(self, lab_hash: str, field_selector: str = None) -> None:
+        """Wait the deletion of the specified Kubernetes secrets. Returns when the secrets are deleted.
+
+        Args:
+            lab_hash (str): The hash of a Kathara network scenario.
+            field_selector (str): The field selector for the secret.
+
+        Returns:
+            None
+        """
+        secrets_to_delete = len(self.client.list_namespaced_secret(lab_hash, field_selector=field_selector).items)
+
+        if secrets_to_delete > 0:
+            w = watch.Watch()
+            deleted_secrets = 0
+            for event in w.stream(self.client.list_namespaced_secret, namespace=lab_hash, field_selector=field_selector):
+                logging.debug(f"Event: {event['type']} - Secret: {event['object'].metadata.name}")
+
+                if event['type'] == "DELETED":
+                    deleted_secrets += 1
+
+                if deleted_secrets == secrets_to_delete:
+                    w.stop()

--- a/src/Kathara/setting/Setting.py
+++ b/src/Kathara/setting/Setting.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, List
 
 from .. import utils
 from .. import version
-from ..exceptions import HTTPConnectionError, SettingsError, SettingsNotFoundError
+from ..exceptions import HTTPConnectionError, SettingsError, SettingsNotFoundError, InvalidDockerConfigJSONError
 from ..exceptions import InstantiationError
 from ..foundation.setting.SettingsAddon import SettingsAddon
 from ..foundation.setting.SettingsAddonFactory import SettingsAddonFactory
@@ -292,6 +292,24 @@ class Setting(object):
             raise SettingsError("Terminal Emulator `%s` not valid! Install it before using it." % terminal)
 
         return True
+
+    def check_docker_config_json(self, docker_config_json_path: str) -> None:
+        """Check that the specified Docker Config JSON is valid.
+
+        Args:
+            docker_config_json_path (str): The path to the Docker Config JSON file.
+
+        Returns:
+            None
+
+        Raises:
+            InvalidDockerConfigJsonError: If the Docker Config JSON file is not valid.
+        """
+        with open(docker_config_json_path, 'r') as docker_config_json_file:
+            try:
+                json.load(docker_config_json_file)
+            except ValueError:
+                raise InvalidDockerConfigJSONError(docker_config_json_path)
 
     def load_settings_addon(self) -> None:
         """Load a setting addon to the base settings.

--- a/src/Kathara/setting/Setting.py
+++ b/src/Kathara/setting/Setting.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, List
 
 from .. import utils
 from .. import version
-from ..exceptions import HTTPConnectionError, SettingsError, SettingsNotFoundError, InvalidDockerConfigJSONError
+from ..exceptions import HTTPConnectionError, SettingsError, SettingsNotFoundError, InvalidDockerConfigJsonError
 from ..exceptions import InstantiationError
 from ..foundation.setting.SettingsAddon import SettingsAddon
 from ..foundation.setting.SettingsAddonFactory import SettingsAddonFactory
@@ -309,7 +309,7 @@ class Setting(object):
             try:
                 json.load(docker_config_json_file)
             except ValueError:
-                raise InvalidDockerConfigJSONError(docker_config_json_path)
+                raise InvalidDockerConfigJsonError(docker_config_json_path)
 
     def load_settings_addon(self) -> None:
         """Load a setting addon to the base settings.

--- a/src/Kathara/setting/addon/KubernetesSettingsAddon.py
+++ b/src/Kathara/setting/addon/KubernetesSettingsAddon.py
@@ -6,23 +6,26 @@ DEFAULTS = {
     "api_server_url": "Empty String",
     "api_token": "Empty String",
     "host_shared": True,
-    "image_pull_policy": "IfNotPresent"
+    "image_pull_policy": "IfNotPresent",
+    "private_registry_dockerconfigjson": "Empty String"
 }
 
 
 class KubernetesSettingsAddon(SettingsAddon):
-    __slots__ = ['api_server_url', 'api_token', 'host_shared', 'image_pull_policy']
+    __slots__ = ['api_server_url', 'api_token', 'host_shared', 'image_pull_policy', 'private_registry_dockerconfigjson']
 
     def __init__(self) -> None:
         self.api_server_url: Optional[str] = None
         self.api_token: Optional[str] = None
         self.host_shared: bool = True
         self.image_pull_policy: Optional[str] = "IfNotPresent"
+        self.private_registry_dockerconfigjson: Optional[str] = None
 
     def _to_dict(self) -> Dict[str, Any]:
         return {
             'api_server_url': self.api_server_url,
             'api_token': self.api_token,
             'host_shared': self.host_shared,
-            'image_pull_policy': self.image_pull_policy
+            'image_pull_policy': self.image_pull_policy,
+            'private_registry_dockerconfigjson': self.private_registry_dockerconfigjson
         }

--- a/src/Kathara/setting/addon/KubernetesSettingsAddon.py
+++ b/src/Kathara/setting/addon/KubernetesSettingsAddon.py
@@ -7,19 +7,19 @@ DEFAULTS = {
     "api_token": "Empty String",
     "host_shared": True,
     "image_pull_policy": "IfNotPresent",
-    "private_registry_dockerconfigjson": "Empty String"
+    "docker_config_json": "Empty String"
 }
 
 
 class KubernetesSettingsAddon(SettingsAddon):
-    __slots__ = ['api_server_url', 'api_token', 'host_shared', 'image_pull_policy', 'private_registry_dockerconfigjson']
+    __slots__ = ['api_server_url', 'api_token', 'host_shared', 'image_pull_policy', 'docker_config_json']
 
     def __init__(self) -> None:
         self.api_server_url: Optional[str] = None
         self.api_token: Optional[str] = None
         self.host_shared: bool = True
         self.image_pull_policy: Optional[str] = "IfNotPresent"
-        self.private_registry_dockerconfigjson: Optional[str] = None
+        self.docker_config_json: Optional[str] = None
 
     def _to_dict(self) -> Dict[str, Any]:
         return {
@@ -27,5 +27,5 @@ class KubernetesSettingsAddon(SettingsAddon):
             'api_token': self.api_token,
             'host_shared': self.host_shared,
             'image_pull_policy': self.image_pull_policy,
-            'private_registry_dockerconfigjson': self.private_registry_dockerconfigjson
+            'docker_config_json': self.docker_config_json
         }

--- a/src/Kathara/validator/DockerConfigJSONValidator.py
+++ b/src/Kathara/validator/DockerConfigJSONValidator.py
@@ -1,0 +1,16 @@
+from ..exceptions import InvalidDockerConfigJSONError
+from ..setting.Setting import Setting
+from ..trdparty.consolemenu.validators.base import BaseValidator
+
+
+class DockerConfigJSONValidator(BaseValidator):
+    def __init__(self) -> None:
+        super(DockerConfigJSONValidator, self).__init__()
+
+    def validate(self, input_string: str) -> bool:
+        try:
+            Setting.get_instance().check_docker_config_json(input_string)
+            return True
+        except (OSError, InvalidDockerConfigJSONError) as e:
+            print(str(e))
+            return False

--- a/src/Kathara/validator/DockerConfigJsonValidator.py
+++ b/src/Kathara/validator/DockerConfigJsonValidator.py
@@ -1,16 +1,16 @@
-from ..exceptions import InvalidDockerConfigJSONError
+from ..exceptions import InvalidDockerConfigJsonError
 from ..setting.Setting import Setting
 from ..trdparty.consolemenu.validators.base import BaseValidator
 
 
-class DockerConfigJSONValidator(BaseValidator):
+class DockerConfigJsonValidator(BaseValidator):
     def __init__(self) -> None:
-        super(DockerConfigJSONValidator, self).__init__()
+        super(DockerConfigJsonValidator, self).__init__()
 
     def validate(self, input_string: str) -> bool:
         try:
             Setting.get_instance().check_docker_config_json(input_string)
             return True
-        except (OSError, InvalidDockerConfigJSONError) as e:
+        except (OSError, InvalidDockerConfigJsonError) as e:
             print(str(e))
             return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/KatharaFramework/Kathara/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Added new Kubernetes setting `private_registry_dockerconfigjson` for a base64-encoded docker configuration.
- When creating a namespace, if the setting above is set, create also a Kubernetes secret named `private-registry` of type `kubernetes.io/dockerconfigjson`.
- When creating the machines, if the setting above is set, add the `image_pull_secret` argument to the pod specification referring to the `private-registry` secret.

**- How I did it**
- Edited `KubernetesSettingsAddon.py` to add the new setting `private_registry_dockerconfigjson`.
- Edited `KubernetesOptionHandler.py` to add the cli menu to enter or delete the setting.
- Edited `KubernetesNamespace.py` to create the `private-registry` secret if the setting is set right after creating the namespace.
- Edited `KubernetesMachine.py` to add the `image_pull_secret` argument to the pod specification referring to the `private-registry` secret if the setting is set.

**- How to verify it**
Create a private registry and get the docker config. Example of the file structure:
```json
{
    "auths": {
        "https://index.docker.io/v1/": {
            "auth": "c3R...zE2"
        }
    }
}
```
Compute the base64 encoding of the docker config and add it to Kathara settings.
Deploy a lab with `kathara lstart` or a machine with `kathara vstart` with an image available on the private registry.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added support for private registries on Megalos

Resolves #283.
