### PR TITLE
Feature/ allow ulimits parameters configuration of the devices

### DIFF
--- a/docs/kathara-lab.conf.5.ronn
+++ b/docs/kathara-lab.conf.5.ronn
@@ -74,6 +74,13 @@ If `arg` is an option name, then `device` will be launched with option `arg` set
 * `num_terms` (integer):
 	Choose the number of terminals to open for this device.
 
+* `ulimit` (string):
+	Allows change of both soft and hard limits. The syntax is ULIMIT=SOFT:HARD.
+	Use -1 for ulimited. 
+	If only a parameter is given e.g. ULIMIT=VALUE both soft and hard limit will have same value.
+	For instance, with this command is possible to set memlock soft and hard limit to unlimited: `device[ulimit]="memlock=-1:-1`.
+
+
 ## NETWORK SCENARIO META INFORMATION
 
 It is also possible to provide descriptive information about a network scenario by using one of the following special assignments:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kathara"
-version = "3.7.6"
+version = "3.7.7"
 description = "A lightweight container-based network emulation tool."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/Linux-Deb/Makefile
+++ b/scripts/Linux-Deb/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-VERSION=3.7.6
+VERSION=3.7.7
 DEBIAN_PACKAGE_VERSION=1
 LAUNCHPAD_NAME=user
 NO_BINARY_PACKAGES=pyroute2|pyuv|deepdiff

--- a/scripts/Linux-Deb/debian/changelog
+++ b/scripts/Linux-Deb/debian/changelog
@@ -1,7 +1,3 @@
 kathara (__VERSION__-__DEBIAN_PACKAGE_VERSION____UBUNTU_VERSION__) __UBUNTU_VERSION__; urgency=low
-
-    * Fix IPv6 disabling issue
-    * Add the possibility to exclude machines while deploying a network scenario, both from CLI and Python APIs
-    * Minor fixes
-
+    * Adding the possibility to change ulimit parameters for devices
  -- Kathara Team <contact@kathara.org>  __DATE__

--- a/src/Kathara/manager/kubernetes/KubernetesMachine.py
+++ b/src/Kathara/manager/kubernetes/KubernetesMachine.py
@@ -302,6 +302,10 @@ class KubernetesMachine(object):
         # If bridged is defined for the device, throw a warning.
         if "bridged" in global_machine_metadata or machine.is_bridged():
             logging.warning('Bridged option is not supported on Megalos. It will be ignored.')
+        
+        # If any ulimit is defined fot the device throw a warning
+        if "ulimit" in global_machine_metadata or "ulimits" in machine.meta:
+            logging.warning('Ulimit option is not supported on Megalos. It will be ignored.')
 
         # If any exec command is passed in command line, add it.
         if "exec" in global_machine_metadata:

--- a/src/Kathara/model/Machine.py
+++ b/src/Kathara/model/Machine.py
@@ -206,7 +206,10 @@ class Machine(FilesystemMixin):
                 if hard is not None:
                     hard = int(hard.strip())
                 else:
-                    hard = soft  # if hard limit is not specified, set it to the same as soft limit
+                    hard = soft  
+                
+                if soft > hard:
+                    soft = hard
 
                 old_value = self.meta['ulimits'].get(key, None)
 

--- a/src/Kathara/model/Machine.py
+++ b/src/Kathara/model/Machine.py
@@ -291,6 +291,10 @@ class Machine(FilesystemMixin):
         if 'shell' in args and args['shell'] is not None:
             self.add_meta("shell", args['shell'])
 
+        if 'ulimits' in args and args['ulimits'] is not None:
+            for ulimit in args['ulimits']:
+                self.add_meta("ulimit", ulimit)
+
     def check(self) -> None:
         """Sort interfaces and check if there are missing interface numbers.
 

--- a/src/Kathara/model/Machine.py
+++ b/src/Kathara/model/Machine.py
@@ -68,6 +68,7 @@ class Machine(FilesystemMixin):
             'sysctls': {},
             'envs': {},
             'ports': {},
+            'ulimits': {}
         }
 
         self.api_object: Any = None
@@ -190,6 +191,29 @@ class Machine(FilesystemMixin):
                 self.meta['envs'][key] = val
             else:
                 raise MachineOptionError("Invalid env value (`%s`) on `%s`." % (value, self.name))
+            return old_value
+            
+        if name == "ulimit":
+            # regex pattern to match key and value pairs for ulimits of the form key=soft:hard
+            matches = re.search(r"^(?P<key>\w+)=(?P<soft>-?\d+)(:(?P<hard>-?\d+))?$", value)
+            
+            # check for valid ulimit pair
+            if matches:
+                key = matches.group("key").strip()
+                soft = int(matches.group("soft").strip())
+                hard = matches.group("hard")
+                
+                if hard is not None:
+                    hard = int(hard.strip())
+                else:
+                    hard = soft  # if hard limit is not specified, set it to the same as soft limit
+
+                old_value = self.meta['ulimits'].get(key, None)
+
+                self.meta['ulimits'][key] = {'soft': soft, 'hard': hard}
+            else:
+                raise MachineOptionError(f"Invalid ulimit value (`{value}`) on `{name}`.")
+            
             return old_value
 
         if name == "port":
@@ -433,6 +457,13 @@ class Machine(FilesystemMixin):
                 raise MachineOptionError("CPU value not valid on `%s`." % self.name)
 
         return None
+    
+    def get_ulimits(self) -> Optional[Dict[str, Dict[str, int]]]:
+        """Get the ulimits dictionary
+        Returns:
+            Optional[Dict[str, Dict[str, int]]]: The ulimits of the device.
+        """
+        return self.meta.get("ulimits", None)
 
     def get_shell(self) -> str:
         """Get the custom shell specified for the device.

--- a/src/Kathara/model/Machine.py
+++ b/src/Kathara/model/Machine.py
@@ -208,7 +208,18 @@ class Machine(FilesystemMixin):
                 else:
                     hard = soft  
                 
-                if soft > hard:
+               
+                if soft < -1 or hard < -1:
+                    raise MachineOptionError(f"Invalid ulimit value (`{value}`) on `{name}`. Values must be >= -1")
+                
+                
+                if soft == -1 and hard != -1:
+                    raise MachineOptionError(f"Invalid ulimit value (`{value}`) on `{name}`. Soft limit (-1) cannot be greater than hard limit ({hard})")
+                
+                if soft != -1 and hard == -1:
+                    # valid case, leave as is since hard limit is unlimited
+                    pass
+                elif soft > hard:
                     soft = hard
 
                 old_value = self.meta['ulimits'].get(key, None)

--- a/src/Kathara/version.py
+++ b/src/Kathara/version.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-CURRENT_VERSION = "3.7.6"
+CURRENT_VERSION = "3.7.7"
 
 
 def parse(version: str) -> Tuple:

--- a/tests/manager/docker/docker_machine_test.py
+++ b/tests/manager/docker/docker_machine_test.py
@@ -142,7 +142,8 @@ def test_create(mock_get_current_user_name, mock_setting_get_instance, mock_copy
         detach=True,
         volumes={},
         labels={'name': 'test_device', 'lab_hash': '9pe3y6IDMwx4PfOPu5mbNg', 'user': 'test-user', 'app': 'kathara',
-                'shell': '/bin/bash'}
+                'shell': '/bin/bash'},
+        ulimits=[]
     )
 
     assert not mock_copy_files.called
@@ -198,7 +199,8 @@ def test_create_ipv6(mock_get_current_user_name, mock_setting_get_instance, mock
         detach=True,
         volumes={},
         labels={'name': 'test_device', 'lab_hash': '9pe3y6IDMwx4PfOPu5mbNg', 'user': 'test-user', 'app': 'kathara',
-                'shell': '/bin/bash'}
+                'shell': '/bin/bash'},
+        ulimits=[]
     )
 
     assert not mock_copy_files.called
@@ -254,7 +256,8 @@ def test_create_privileged(mock_get_current_user_name, mock_setting_get_instance
         detach=True,
         volumes={},
         labels={'name': 'test_device', 'lab_hash': '9pe3y6IDMwx4PfOPu5mbNg', 'user': 'test-user', 'app': 'kathara',
-                'shell': '/bin/bash'}
+                'shell': '/bin/bash'},
+        ulimits=[]
     )
     assert not mock_copy_files.called
 
@@ -320,7 +323,8 @@ def test_create_interface(mock_get_current_user_name, mock_setting_get_instance,
         detach=True,
         volumes={},
         labels={'name': 'test_device', 'lab_hash': '9pe3y6IDMwx4PfOPu5mbNg', 'user': 'test-user', 'app': 'kathara',
-                'shell': '/bin/bash'}
+                'shell': '/bin/bash'},
+        ulimits=[]
     )
 
     assert not mock_copy_files.called
@@ -388,7 +392,8 @@ def test_create_interface_old_engine(mock_get_current_user_name, mock_setting_ge
         detach=True,
         volumes={},
         labels={'name': 'test_device', 'lab_hash': '9pe3y6IDMwx4PfOPu5mbNg', 'user': 'test-user', 'app': 'kathara',
-                'shell': '/bin/bash'}
+                'shell': '/bin/bash'},
+        ulimits=[]
     )
 
     assert not mock_copy_files.called
@@ -463,7 +468,8 @@ def test_create_interface_mac_addr(mock_get_current_user_name, mock_setting_get_
         detach=True,
         volumes={},
         labels={'name': 'test_device', 'lab_hash': '9pe3y6IDMwx4PfOPu5mbNg', 'user': 'test-user', 'app': 'kathara',
-                'shell': '/bin/bash'}
+                'shell': '/bin/bash'},
+        ulimits=[]
     )
 
     assert not mock_copy_files.called
@@ -539,7 +545,8 @@ def test_create_interface_mac_addr_on_old_engine(mock_get_current_user_name, moc
         detach=True,
         volumes={},
         labels={'name': 'test_device', 'lab_hash': '9pe3y6IDMwx4PfOPu5mbNg', 'user': 'test-user', 'app': 'kathara',
-                'shell': '/bin/bash'}
+                'shell': '/bin/bash'},
+        ulimits=[]
     )
 
     assert not mock_copy_files.called

--- a/tests/model/machine_test.py
+++ b/tests/model/machine_test.py
@@ -29,6 +29,7 @@ def test_default_device_parameters(default_device: Machine):
         'sysctls': {},
         'envs': {},
         'ports': {},
+        'ulimits': {}
     }
     assert default_device.api_object is None
     assert default_device.fs is None
@@ -281,6 +282,26 @@ def test_add_meta_overwrite_port(default_device: Machine):
     result = default_device.add_meta("port", "3000:5000")
     assert default_device.meta["ports"][(3000, "tcp")] == 5000
     assert result == 4000
+
+def test_add_meta_ulimit(default_device):
+    default_device.add_meta("ulimit", "nofile=1024:2048")
+    assert default_device.meta['ulimits']['nofile'] == {'soft': 1024, 'hard': 2048}
+
+def test_add_meta_ulimit_soft_only(default_device):
+    default_device.add_meta("ulimit", "nofile=1024")
+    assert default_device.meta['ulimits']['nofile'] == {'soft': 1024, 'hard': 1024}
+
+def test_add_meta_ulimit_negative_value(default_device):
+    default_device.add_meta("ulimit", "memlock=-1")
+    assert default_device.meta['ulimits']['memlock'] == {'soft': -1, 'hard': -1}
+
+def test_add_meta_ulimit_invalid_format(default_device):
+    with pytest.raises(MachineOptionError):
+        default_device.add_meta("ulimit", "nofile=1024:2048:4096")
+
+def test_add_meta_ulimit_not_format_exception(default_device):
+    with pytest.raises(MachineOptionError):
+        default_device.add_meta("ulimit", "nofile1024")
 
 
 #

--- a/tests/model/machine_test.py
+++ b/tests/model/machine_test.py
@@ -303,6 +303,25 @@ def test_add_meta_ulimit_not_format_exception(default_device):
     with pytest.raises(MachineOptionError):
         default_device.add_meta("ulimit", "nofile1024")
 
+def test_add_meta_ulimit_soft_greater_than_hard(default_device):
+    default_device.add_meta("ulimit", "nofile=2048:1024")
+    assert default_device.meta['ulimits']['nofile'] == {'soft': 1024, 'hard': 1024}
+
+def test_add_meta_ulimit_soft_unlimited_hard_limited(default_device):
+    with pytest.raises(MachineOptionError):
+        default_device.add_meta("ulimit", "nofile=-1:1024")
+
+def test_add_meta_ulimit_soft_limited_hard_unlimited(default_device):
+    default_device.add_meta("ulimit", "nofile=2048:-1")
+    assert default_device.meta['ulimits']['nofile'] == {'soft': 2048, 'hard': -1}
+
+def test_add_meta_ulimit_soft_and_hard_unlimited(default_device):
+    default_device.add_meta("ulimit", "nofile=-1:-1")
+    assert default_device.meta['ulimits']['nofile'] == {'soft': -1, 'hard': -1}
+
+def test_add_meta_ulimit_invalid_value(default_device):
+    with pytest.raises(MachineOptionError):
+        default_device.add_meta("ulimit", "nofile=1024:-2")
 
 #
 # TEST: check


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/KatharaFramework/Kathara/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

I've introduced the possibility to set ulimits in the devices via lab.conf file

**-Changed files**
The following files have been modified:
- src/Kathara/manager/docker/DockerMachine.py:
  - to be able to support the ulimits instances upon container creation.
  - _create_ulimit_instances method was introduced to parse a ulimits dictionary to ulimit instances following the docker sdk requirements
- src/Kathara/model/Machine.py:
  - the add_meta method is now able to parse strings  like _yourdevice_[ulimit]="_ulimit_=_softlimit_:_hardlimit_" or _yourdevice_[ulimit]="_ulimit_=_softlimit_" in the second case _hardlimit_ will be set to be equal to _softlimit_
  - get_ulimits method was introduced to retrieve the dictionary of ulimits
- tests/model/machine_test.py, added tests to verify correct parsing 
- docs/kathara-lab.conf.5.ronn, added some lines to explain how to set ulimits

**- How to verify it**
- Create a lab.conf with a some devices then set _yourdevice_[ulimit]="nofile=1000:1000" or _yourdevice_[ulimit]="memlock=-1"
- start the lab
- in the terminal of the device run ulimit -a 
- check that ulimit you've set in lab conf matches printed value in the teminal

**- Description for the changelog**
Lab.conf now supports ulimits configuration at device creation, this solves cases where specific containers need to be run with custom values as in "docker run --ulimit memlock=819200000:819200000 ..."