### PR TITLE
Remove outdated slug dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "docker>=7.0.0",
     "kubernetes>=23.3.0",
     "requests>=2.22.0",
-    "slug>=2.0",
     "pyroute2",
     "rich",
     "fs>=2.4.16",

--- a/scripts/autocompletion/requirements.txt
+++ b/scripts/autocompletion/requirements.txt
@@ -1,6 +1,5 @@
 binaryornot>=0.4.4
 requests>=2.22.0
-slug>=2.0
 kubernetes>=23.3.0
 fs>=2.4.16
 rich

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         "docker>=7.0.0",
         "kubernetes>=23.3.0",
         "requests>=2.22.0",
-        "slug>=2.0",
         "pyroute2",
         "rich",
         "fs>=2.4.16",

--- a/src/Kathara/utils.py
+++ b/src/Kathara/utils.py
@@ -14,11 +14,12 @@ import re
 import shutil
 import tarfile
 import tempfile
+import unicodedata
 
 from binaryornot.check import is_binary
 from io import BytesIO
 from platform import node, machine
-from slug import slug
+
 from types import ModuleType
 from typing import Any, Optional, Match, Generator, List, Callable, Union, Dict, Iterable, Tuple
 
@@ -230,6 +231,10 @@ def get_current_user_uid_gid() -> (int, int):
 
     return exec_by_platform(unix, lambda: (None, None), unix)
 
+def slug(value):
+    value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    value = re.sub(r"[^\w\s-]", "", value).strip().lower()
+    return re.sub(r"[-\s]+", "-", value)
 
 def get_current_user_name() -> str:
     hostname = generate_urlsafe_hash(node())

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,7 +2,6 @@ binaryornot>=0.4.4
 docker>=7.0.0
 kubernetes>=23.3.0
 requests>=2.22.0
-slug>=2.0
 pyroute2
 rich
 fs>=2.4.16


### PR DESCRIPTION
# Remove outdated 'slug' dependency

### Problem
Kathara currently depends on the outdated `slug` package from PyPI. This dependency has not been maintained in years:
- Last push to the repository: 7 years ago
- Last code change: 13 years ago
- Repository: https://github.com/zikzakmedia/python-slug/tree/master

This outdated dependency causes compatibility issues with modern packaging and build systems, including Nix, which I am currently using to create a NixOS package for Kathara.

### Solution
Replaced the external dependency with an inline implementation using `re` and `unicodedata` from the Python standard library. The function performs the same operations as the original:
1. Unicode normalization (NFKD) and ASCII conversion
2. Removal of non-word characters (except spaces and hyphens)
3. Conversion of whitespace and multiple hyphens to single hyphens

### Changes
- Removed `slug` from dependencies
- Added Python 3 implementation of the slug function