### PR TITLE
Suppress pkg_resources deprecation warning from fs library

### DIFF
--- a/src/kathara.py
+++ b/src/kathara.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+import warnings
+
+# Suppress deprecation warning from fs library using pkg_resources
+# See: https://github.com/PyFilesystem/pyfilesystem2/issues/577
+warnings.filterwarnings("ignore", message="pkg_resources is deprecated as an API")
+
 import argparse
 import logging
 import multiprocessing


### PR DESCRIPTION
## Summary
Suppress the `pkg_resources is deprecated` warning that appears on every Kathara command with Python 3.13 and setuptools >= 81.

## Problem
The `fs` (PyFilesystem2) library uses `pkg_resources` internally, which triggers this warning:
```
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30.
```

The upstream issue has been open for 2+ years without resolution:
https://github.com/PyFilesystem/pyfilesystem2/issues/577

## Solution
Add a warning filter at the entry point (`src/kathara.py`) to suppress this specific warning until the `fs` library is updated or replaced with stdlib alternatives.

## Testing
Run any Kathara command - the warning should no longer appear.