### PR TITLE
Added Nix / NixOS installation support trough Flakes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ Dockerfile~
 
 # Pydoc
 /scripts/pydoc/docs
+
+# Nix Build
+/results/

--- a/README-NIX.md
+++ b/README-NIX.md
@@ -1,0 +1,90 @@
+
+
+### NixOS (flake)
+
+If you use this repository as a flake input, add the package (or module) to your NixOS configuration so `kathara` is installed in your system profile and available in `PATH`.
+
+```nix
+# flake.nix
+inputs.kathara.url = "github:KatharaFramework/Kathara";
+
+# configuration.nix
+environment.systemPackages = [
+  inputs.kathara.packages.${pkgs.system}.default
+];
+```
+
+Alternatively, import the module exposed by the flake:
+
+```nix
+# flake.nix
+inputs.kathara.url = "github:KatharaFramework/Kathara";
+
+# configuration.nix
+imports = [ inputs.kathara.nixosModules.default ];
+```
+
+### Home Manager (flake)
+
+The flake also exposes a Home Manager module to install Kathará and manage `~/.config/kathara.conf` declaratively:
+
+```nix
+# flake.nix
+inputs.kathara.url = "github:KatharaFramework/Kathara";
+
+# home.nix
+imports = [ inputs.kathara.homeManagerModules.default ];
+
+programs.kathara = {
+  enable = true;
+  manager = "docker";
+  image = "kathara/base";
+  terminal = "/usr/bin/xterm";
+  openTerminals = true;
+  deviceShell = "/bin/bash";
+  netPrefix = "kathara";
+  devicePrefix = "kathara";
+  debugLevel = "INFO";
+  printStartupLog = true;
+  enableIpv6 = false;
+
+  # Optional: additional raw keys written to kathara.conf
+  settings = { };
+};
+```
+
+Available typed options under `programs.kathara`:
+
+- `enable`
+- `package`
+- `image` (`kathara.conf`: `image`)
+- `manager` (`kathara.conf`: `manager_type`; values: `docker`, `kubernetes`)
+- `terminal` (`kathara.conf`: `terminal`)
+- `openTerminals` (`kathara.conf`: `open_terminals`)
+- `deviceShell` (`kathara.conf`: `device_shell`)
+- `netPrefix` (`kathara.conf`: `net_prefix`)
+- `devicePrefix` (`kathara.conf`: `device_prefix`)
+- `debugLevel` (`kathara.conf`: `debug_level`; values: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, `EXCEPTION`)
+- `printStartupLog` (`kathara.conf`: `print_startup_log`)
+- `enableIpv6` (`kathara.conf`: `enable_ipv6`)
+- `settings` (extra raw JSON keys)
+
+If you are not using flakes, you can still install Kathará from `configuration.nix` using `fetchTarball` and `callPackage`:
+
+```nix
+{ config, pkgs, ... }:
+
+let
+  katharaSrc = builtins.fetchTarball {
+    url = "https://github.com/KatharaFramework/Kathara/archive/refs/tags/3.8.0.tar.gz";
+    # sha256 = "sha256-...";
+  };
+
+  katharaPkg = pkgs.callPackage "${katharaSrc}/nix" { };
+in
+{
+  environment.systemPackages = [
+    katharaPkg
+  ];
+}
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704290814,
+        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,33 +1,43 @@
 {
+  # Flake metadata shown by `nix flake metadata` and similar commands.
   description = "Kathara Nix flake";
 
+  # Pin nixpkgs so package/module behavior is reproducible.
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
 
   outputs =
     { self, nixpkgs }:
     let
+      # Supported target systems for exported packages/apps.
       systems = [
         "x86_64-linux"
         "aarch64-linux"
       ];
+      # Helper: build an attribute set for every supported system.
       forAllSystems = nixpkgs.lib.genAttrs systems;
     in
     {
+      # Overlay exposing `pkgs.kathara` when this flake is imported elsewhere.
       overlays.default = final: prev: {
         kathara = final.callPackage ./nix { };
       };
 
+      # Build package outputs for each supported system.
       packages = forAllSystems (
         system:
         let
+          # Import nixpkgs for the current system.
           pkgs = import nixpkgs { inherit system; };
         in
         rec {
+          # Package expression lives in `./nix/default.nix`.
           kathara = pkgs.callPackage ./nix { };
+          # `nix build` defaults to this package.
           default = kathara;
         }
       );
 
+      # NixOS module: install Kathara system-wide and register the overlay.
       nixosModules.default =
         { pkgs, ... }:
         {
@@ -35,8 +45,10 @@
           environment.systemPackages = [ pkgs.kathara ];
         };
 
+      # Home Manager module exported by this flake.
       homeManagerModules.default = import ./nix/home-manager.nix;
 
+      # `nix run` entrypoint -> `kathara` executable from the default package.
       apps = forAllSystems (system: {
         default = {
           type = "app";

--- a/flake.nix
+++ b/flake.nix
@@ -22,13 +22,11 @@
         let
           pkgs = import nixpkgs { inherit system; };
         in
-        {
+        rec {
           kathara = pkgs.callPackage ./nix { };
-          default = self.packages.${system}.kathara;
+          default = kathara;
         }
       );
-
-      defaultPackage = forAllSystems (system: self.packages.${system}.default);
 
       nixosModules.default =
         { pkgs, ... }:
@@ -42,7 +40,7 @@
       apps = forAllSystems (system: {
         default = {
           type = "app";
-          program = "${self.packages.${system}.kathara}/bin/kathara";
+          program = "${self.packages.${system}.default}/bin/kathara";
         };
       });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Kathara Nix flake";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      overlays.default = final: prev: {
+        kathara = final.callPackage ./nix { };
+      };
+
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          kathara = pkgs.callPackage ./nix { };
+          default = self.packages.${system}.kathara;
+        }
+      );
+
+      defaultPackage = forAllSystems (system: self.packages.${system}.default);
+
+      nixosModules.default =
+        { pkgs, ... }:
+        {
+          nixpkgs.overlays = [ self.overlays.default ];
+          environment.systemPackages = [ pkgs.kathara ];
+        };
+
+      homeManagerModules.default = import ./nix/home-manager.nix;
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.kathara}/bin/kathara";
+        };
+      });
+    };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,23 +13,6 @@
   tmux,
 }:
 
-let
-  versions = {
-    binaryornot = "0.4.4";
-    docker = "7.0.0";
-    kubernetes = "23.3.0";
-    requests = "2.22.0";
-    slug = "2.0";
-    fs = "2.4.16";
-    libtmux = "0.8.2";
-    appscript = "1.1.0";
-    pypiwin32 = "223";
-    windows-curses = "2.1.0";
-    chardet = "";
-    rich = "";
-    pyroute2 = "";
-  };
-in
 python3Packages.buildPythonApplication rec {
   pname = "kathara";
   version = "3.8.0";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,6 +13,23 @@
   tmux,
 }:
 
+let
+  versions = {
+    binaryornot = "0.4.4";
+    docker = "7.0.0";
+    kubernetes = "23.3.0";
+    requests = "2.22.0";
+    slug = "2.0";
+    fs = "2.4.16";
+    libtmux = "0.8.2";
+    appscript = "1.1.0";
+    pypiwin32 = "223";
+    windows-curses = "2.1.0";
+    chardet = "";
+    rich = "";
+    pyroute2 = "";
+  };
+in
 python3Packages.buildPythonApplication rec {
   pname = "kathara";
   version = "3.8.0";
@@ -49,17 +66,7 @@ python3Packages.buildPythonApplication rec {
         };
       };
 
-      dockerPython = python3Packages.docker.overridePythonAttrs (old: rec {
-        version = "7.0.0";
-        src = fetchPypi {
-          pname = old.pname;
-          inherit version;
-          hash = "sha256-Mjc2+5LNlBj8XnEzvJU+EanaBPRIP4KLUn21U/Hn5aM=";
-        };
-        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ python3Packages.setuptools-scm ];
-        SETUPTOOLS_SCM_PRETEND_VERSION = version;
-      });
-
+      dockerPython = python3Packages.docker;
     in
     [
       dockerPython
@@ -67,10 +74,10 @@ python3Packages.buildPythonApplication rec {
       networkx
       pyroute2
       tabulate
-      requests
-      pyuv
       rich
       fs
+      pyuv
+      requests
       chardet
       libtmux
       slug
@@ -136,7 +143,14 @@ python3Packages.buildPythonApplication rec {
     install -d -m 755 "$out/bin"
     makeWrapper ${python3Packages.python}/bin/python "$out/bin/$pname" \
       --add-flags "$out/share/$pname/src/kathara.py" \
-      --prefix PATH : "${lib.makeBinPath [ docker tmux xterm ]}" \
+      --set PYTHONWARNINGS "ignore:pkg_resources is deprecated as an API:UserWarning:fs" \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          docker
+          tmux
+          xterm
+        ]
+      }" \
       --prefix PYTHONPATH : "${python3Packages.makePythonPath propagatedBuildInputs}:$out/share/$pname/src"
 
     runHook postInstall

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,8 +16,10 @@
 python3Packages.buildPythonApplication rec {
   pname = "kathara";
   version = "3.8.0";
+  # Upstream project uses its own Makefiles/build scripts, so keep custom phases.
   format = "other";
 
+  # Build from an exact upstream tag/revision for reproducibility.
   src = fetchFromGitHub {
     owner = "KatharaFramework";
     repo = "Kathara";
@@ -26,6 +28,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [
+    # Used to create wrapper scripts and generate manpages/completions at build time.
     makeWrapper
     ronn
     chrpath
@@ -37,6 +40,7 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs =
     with python3Packages;
     let
+      # `slug` is not provided by nixpkgs under the expected import name.
       slug = buildPythonPackage rec {
         pname = "slug";
         version = "2.0";
@@ -49,6 +53,7 @@ python3Packages.buildPythonApplication rec {
         };
       };
 
+      # Keep explicit aliasing for readability where package name conflicts are possible.
       dockerPython = python3Packages.docker;
     in
     [
@@ -70,10 +75,12 @@ python3Packages.buildPythonApplication rec {
   buildPhase = ''
     runHook preBuild
 
+    # Convert docs/*.ronn into manpage roff files.
     pushd docs
     make roff-build
     popd
 
+    # Generate Bash completion script consumed during install phase.
     pushd scripts/autocompletion
     python generate_autocompletion.py kathara.bash-completion
     popd
@@ -90,6 +97,7 @@ python3Packages.buildPythonApplication rec {
   installPhase = ''
     runHook preInstall
 
+    # Move generated man pages under section-specific directories (man1, man5, ...).
     for man_file in docs/Roff/*; do
       section="''${man_file##*.}"
       man_file_dir="man$section"
@@ -108,6 +116,7 @@ python3Packages.buildPythonApplication rec {
     install -p -m 755 src/kathara.py "$out/share/$pname/src/"
 
     install -d -m 755 "$out/libexec"
+    # Stable xterm wrapper so Kathara doesn't depend on /usr/bin paths.
     cat > "$out/libexec/kathara-xterm" <<'EOF'
     #!${stdenv.shell}
     exec ${xterm}/bin/xterm -fa Monospace "$@"
@@ -117,13 +126,16 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace "$out/share/$pname/src/Kathara/setting/Setting.py" \
       --replace "'/usr/bin/xterm'" "'$out/libexec/kathara-xterm'"
 
+    # Add retry loop to `connect` UI command to avoid race on just-started devices.
     substituteInPlace "$out/share/$pname/src/Kathara/cli/ui/utils.py" \
       --replace "command.append(connect_command)" "command.extend([\"sh\", \"-lc\", \"for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do %s && break; sleep 0.2; done\" % connect_command])"
 
+    # Pass lab directory explicitly to `kathara connect` from the UI helper.
     substituteInPlace "$out/share/$pname/src/Kathara/cli/ui/utils.py" \
       --replace "connect_command = \"%s connect %s -l %s\" % (executable_path, is_vmachine, machine.name)" "connect_command = \"%s connect %s -d \\\"%s\\\" -l %s\" % (executable_path, is_vmachine, machine.lab.fs_path(), machine.name)"
 
     install -d -m 755 "$out/bin"
+    # Wrap launcher with runtime PATH/PYTHONPATH and warning filter.
     makeWrapper ${python3Packages.python}/bin/python "$out/bin/$pname" \
       --add-flags "$out/share/$pname/src/kathara.py" \
       --set PYTHONWARNINGS "ignore:pkg_resources is deprecated as an API:UserWarning:fs" \

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,154 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+  fetchPypi,
+  ronn,
+  makeWrapper,
+  m4,
+  chrpath,
+  xterm,
+  docker,
+  tmux,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "kathara";
+  version = "3.8.0";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "KatharaFramework";
+    repo = "Kathara";
+    rev = version;
+    hash = "sha256-771BJANCgYuV5ebdqPWIbykcanEZP+duTkbYQdwL8cU=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    ronn
+    chrpath
+    m4
+    python3Packages.setuptools
+    python3Packages.pytest
+  ];
+
+  propagatedBuildInputs =
+    with python3Packages;
+    let
+      slug = buildPythonPackage rec {
+        pname = "slug";
+        version = "2.0";
+        format = "wheel";
+        src = fetchPypi {
+          inherit pname version format;
+          hash = "sha256-9VskoFY0KM5WJDB59q63nA3RzFu/izmxC9blJjuovl8=";
+          dist = "py3";
+          python = "py3";
+        };
+      };
+
+      dockerPython = python3Packages.docker.overridePythonAttrs (old: rec {
+        version = "7.0.0";
+        src = fetchPypi {
+          pname = old.pname;
+          inherit version;
+          hash = "sha256-Mjc2+5LNlBj8XnEzvJU+EanaBPRIP4KLUn21U/Hn5aM=";
+        };
+        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ python3Packages.setuptools-scm ];
+        SETUPTOOLS_SCM_PRETEND_VERSION = version;
+      });
+
+    in
+    [
+      dockerPython
+      binaryornot
+      networkx
+      pyroute2
+      tabulate
+      requests
+      pyuv
+      rich
+      fs
+      chardet
+      libtmux
+      slug
+      kubernetes
+    ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd docs
+    make roff-build
+    popd
+
+    pushd scripts/autocompletion
+    python generate_autocompletion.py kathara.bash-completion
+    popd
+
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    pytest tests
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    for man_file in docs/Roff/*; do
+      section="''${man_file##*.}"
+      man_file_dir="man$section"
+      mkdir -p "docs/Roff/$man_file_dir"
+      mv -f "$man_file" "docs/Roff/$man_file_dir/"
+    done
+
+    install -d -m 755 "$out/share/man"
+    cp -r docs/Roff/* "$out/share/man/"
+
+    install -d -m 755 "$out/share/bash-completion/completions"
+    install -p -m 644 scripts/autocompletion/kathara.bash-completion "$out/share/bash-completion/completions/kathara"
+
+    install -d -m 755 "$out/share/$pname/src"
+    cp -r src/Kathara "$out/share/$pname/src/"
+    install -p -m 755 src/kathara.py "$out/share/$pname/src/"
+
+    install -d -m 755 "$out/libexec"
+    cat > "$out/libexec/kathara-xterm" <<'EOF'
+    #!${stdenv.shell}
+    exec ${xterm}/bin/xterm -fa Monospace "$@"
+    EOF
+    chmod 755 "$out/libexec/kathara-xterm"
+
+    substituteInPlace "$out/share/$pname/src/Kathara/setting/Setting.py" \
+      --replace "'/usr/bin/xterm'" "'$out/libexec/kathara-xterm'"
+
+    substituteInPlace "$out/share/$pname/src/Kathara/cli/ui/utils.py" \
+      --replace "command.append(connect_command)" "command.extend([\"sh\", \"-lc\", \"for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do %s && break; sleep 0.2; done\" % connect_command])"
+
+    substituteInPlace "$out/share/$pname/src/Kathara/cli/ui/utils.py" \
+      --replace "connect_command = \"%s connect %s -l %s\" % (executable_path, is_vmachine, machine.name)" "connect_command = \"%s connect %s -d \\\"%s\\\" -l %s\" % (executable_path, is_vmachine, machine.lab.fs_path(), machine.name)"
+
+    install -d -m 755 "$out/bin"
+    makeWrapper ${python3Packages.python}/bin/python "$out/bin/$pname" \
+      --add-flags "$out/share/$pname/src/kathara.py" \
+      --prefix PATH : "${lib.makeBinPath [ docker tmux xterm ]}" \
+      --prefix PYTHONPATH : "${python3Packages.makePythonPath propagatedBuildInputs}:$out/share/$pname/src"
+
+    runHook postInstall
+  '';
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A lightweight container-based network emulation tool";
+    homepage = "https://www.kathara.org/";
+    license = licenses.gpl3Only;
+    mainProgram = "kathara";
+    platforms = platforms.linux;
+  };
+}

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -1,0 +1,136 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.kathara;
+  jsonFormat = pkgs.formats.json { };
+  typedSettings = lib.filterAttrs (_: value: value != null) {
+    image = cfg.image;
+    manager_type = cfg.manager;
+    terminal = cfg.terminal;
+    open_terminals = cfg.openTerminals;
+    device_shell = cfg.deviceShell;
+    net_prefix = cfg.netPrefix;
+    device_prefix = cfg.devicePrefix;
+    debug_level = cfg.debugLevel;
+    print_startup_log = cfg.printStartupLog;
+    enable_ipv6 = cfg.enableIpv6;
+  };
+in
+{
+  options.programs.kathara = {
+    enable = lib.mkEnableOption "Kathara";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = if pkgs ? kathara then pkgs.kathara else pkgs.callPackage ../nix { };
+      description = "Kathara package to install.";
+    };
+
+    image = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "kathara/base";
+      description = "Default image used by Kathara devices (kathara.conf key: image).";
+    };
+
+    manager = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "docker"
+          "kubernetes"
+        ]
+      );
+      default = null;
+      example = "docker";
+      description = "Manager backend (kathara.conf key: manager_type).";
+    };
+
+    terminal = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/usr/bin/xterm";
+      description = "Terminal command used by Kathara (kathara.conf key: terminal).";
+    };
+
+    openTerminals = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = "Automatically open terminals when starting devices (kathara.conf key: open_terminals).";
+    };
+
+    deviceShell = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/bin/bash";
+      description = "Default shell inside devices (kathara.conf key: device_shell).";
+    };
+
+    netPrefix = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "kathara";
+      description = "Prefix for network names (kathara.conf key: net_prefix).";
+    };
+
+    devicePrefix = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "kathara";
+      description = "Prefix for device names (kathara.conf key: device_prefix).";
+    };
+
+    debugLevel = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "CRITICAL"
+          "ERROR"
+          "WARNING"
+          "INFO"
+          "DEBUG"
+          "EXCEPTION"
+        ]
+      );
+      default = null;
+      example = "INFO";
+      description = "Logging level (kathara.conf key: debug_level).";
+    };
+
+    printStartupLog = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = "Print startup logs (kathara.conf key: print_startup_log).";
+    };
+
+    enableIpv6 = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = "Enable IPv6 features (kathara.conf key: enable_ipv6).";
+    };
+
+    settings = lib.mkOption {
+      type = jsonFormat.type;
+      default = { };
+      example = {
+        manager_type = "docker";
+        open_terminals = false;
+      };
+      description = ''
+        Additional raw settings written to ~/.config/kathara.conf.
+        Values defined by typed options (such as manager, image, terminal) take precedence.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."kathara.conf".source = jsonFormat.generate "kathara.conf" (
+      cfg.settings // typedSettings
+    );
+  };
+}

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -7,7 +7,11 @@
 
 let
   cfg = config.programs.kathara;
+  # Final JSON content written to `~/.config/kathara.conf`.
+  # Typed options override same keys from `settings`.
   renderedSettings = builtins.toJSON (cfg.settings // typedSettings);
+  # Translate typed Home Manager options to Kathara config keys.
+  # Null values are dropped, so only explicitly-set keys are emitted.
   typedSettings = lib.filterAttrs (_: value: value != null) {
     image = cfg.image;
     manager_type = cfg.manager;
@@ -22,6 +26,7 @@ let
   };
 in
 {
+  # Home Manager module options under `programs.kathara.*`.
   options.programs.kathara = {
     enable = lib.mkEnableOption "Kathara";
 
@@ -126,9 +131,12 @@ in
     };
   };
 
+  # Effective config: install package and materialize config file when enabled.
   config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
+    # Activation script runs during Home Manager switch.
+    # It writes the JSON config with restricted permissions.
     home.activation.katharaConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
             mkdir -p "${config.xdg.configHome}"
             cat > "${config.xdg.configHome}/kathara.conf" <<'EOF'

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -7,7 +7,6 @@
 
 let
   cfg = config.programs.kathara;
-  jsonFormat = pkgs.formats.json { };
   renderedSettings = builtins.toJSON (cfg.settings // typedSettings);
   typedSettings = lib.filterAttrs (_: value: value != null) {
     image = cfg.image;
@@ -114,7 +113,7 @@ in
     };
 
     settings = lib.mkOption {
-      type = jsonFormat.type;
+      type = (pkgs.formats.json { }).type;
       default = { };
       example = {
         manager_type = "docker";

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -8,6 +8,7 @@
 let
   cfg = config.programs.kathara;
   jsonFormat = pkgs.formats.json { };
+  renderedSettings = builtins.toJSON (cfg.settings // typedSettings);
   typedSettings = lib.filterAttrs (_: value: value != null) {
     image = cfg.image;
     manager_type = cfg.manager;
@@ -129,8 +130,12 @@ in
   config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."kathara.conf".source = jsonFormat.generate "kathara.conf" (
-      cfg.settings // typedSettings
-    );
+    home.activation.katharaConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+            mkdir -p "${config.xdg.configHome}"
+            cat > "${config.xdg.configHome}/kathara.conf" <<'EOF'
+      ${renderedSettings}
+      EOF
+            chmod 600 "${config.xdg.configHome}/kathara.conf"
+    '';
   };
 }


### PR DESCRIPTION
# What I did

Following issue #368, I implemented NixOS integration for Kathara by adding all Nix-related modules, including support for both system-level NixOS usage and Home Manager usage. This way, Kathara can be installed and configured easily on NixOS.

# How I did it

Added the NixOS and Home Manager modules under the Nix packaging setup, exposed them through the flake (nixosModules and homeManagerModules), and documented usage/options for both flake and non-flake users so Kathara can be installed and configured declaratively.

I included the relative documentation in `NIX-README`.

# How to verify it

Verify the correct build of the flake package:
`nix build`

Verify that the flake gets correctly exposed:
(See the README if help is needed adding it to the config)

1. import inputs.kathara.nixosModules.default
2. rebuild with `sudo nixos-rebuild switch --flake .#<host>`

Verify Home Manager module exposure:
1. import inputs.kathara.homeManagerModules.default
2. set programs.kathara.enable = true;
3. apply with home-manager switch --flake .#<user>

Confirm runtime:
1. Run the command `kathara`
2. Verify the presence of the generated config in `~/.config/kathara.conf`.

# Description for the changelog

Added a flake with NixOS and Home Manager modules, enabling declarative installation and configuration of Kathara.